### PR TITLE
Fix crash in case we couldn't import required module

### DIFF
--- a/dagshub/streaming/__init__.py
+++ b/dagshub/streaming/__init__.py
@@ -1,4 +1,9 @@
 from .filesystem import DagsHubFilesystem, install_hooks
-from .mount import mount
+try:
+    from .mount import mount
+except ImportError as e:
+    print(e.msg)
+    def mount(*args, **kwargs):
+        print(e.msg)
 
 __all__ = [DagsHubFilesystem.__name__, install_hooks.__name__, mount.__name__]

--- a/dagshub/streaming/mount.py
+++ b/dagshub/streaming/mount.py
@@ -1,6 +1,7 @@
 import errno
 import logging
 import os
+import platform
 import sys
 from argparse import ArgumentParser
 from os import PathLike
@@ -8,11 +9,18 @@ from pathlib import Path
 from threading import Lock
 from typing import Optional
 
-from fuse import FUSE, FuseOSError, LoggingMixIn, Operations
-
 from .filesystem import SPECIAL_FILE, DagsHubFilesystem
 
 SPECIAL_FILE_FH = (1<<64)-1
+
+fuse_enabled_systems = ["Linux"]
+system = platform.system()
+if system not in fuse_enabled_systems:
+    err_str = f"FUSE mounting isn't supported on {system}.\n" \
+              f"Please use install_hooks to access DagsHub hosted files from a python script"
+    raise ImportError(err_str)
+
+from fuse import FUSE, FuseOSError, LoggingMixIn, Operations
 
 class DagsHubFUSE(LoggingMixIn, Operations):
     def __init__(self,


### PR DESCRIPTION
It doesn't check if the module is installed on an available system btw. There is still a possibility of the later import raising an exception and crashing at init-time