### PR TITLE
Fixes to upload wrapper

### DIFF
--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -48,7 +48,7 @@ class Repo:
 
 		except Exception as e:
 			logger.error(e)
-			exit()
+			raise e
 
 	def upload(self, file: Union[str, IOBase], message, versioning=None, new_branch=None, last_commit=None, path=None):
 		ds = DataSet(self, ".")
@@ -111,12 +111,11 @@ class DataSet:
 
 		except Exception as e:
 			logger.error(e)
-			exit()
+			raise e
 
 	def _reset_dataset(self):
 		self.files = []
 		self.commit_data = Commit()
-
 	def commit(self, message, versioning=None, new_branch=None, last_commit=None):
 		try:
 			data = {}
@@ -172,4 +171,4 @@ class DataSet:
 	
 		except Exception as e:
 			logger.error(e)
-			exit()
+			raise e


### PR DESCRIPTION
- switch from `quit()` to `exit()`
- init DataSet correctly
- send `is_dvc_dir=True` when needed
- reset DataSet after commit