### PR TITLE
Fixing bad cwd handling

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -80,8 +80,9 @@ class DagsHubFilesystem:
                 if ismount(self.project_root):
                     raise ValueError('No git project found! (stopped at mountpoint {self.project_root})')
                 self.project_root = self.project_root / '..'
+            self.project_root = Path(os.path.abspath(self.project_root))
         else:
-            self.project_root = Path(project_root)
+            self.project_root = Path(os.path.abspath(project_root))
         del project_root
         # TODO: if no Git project found, search for .dvc project?
 

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -75,12 +75,11 @@ class DagsHubFilesystem:
 
         # Find root directory of Git project
         if not project_root:
-            self.project_root = Path('.')
+            self.project_root = Path(os.path.abspath('.'))
             while not (self.project_root / '.git').is_dir():
                 if ismount(self.project_root):
                     raise ValueError('No git project found! (stopped at mountpoint {self.project_root})')
                 self.project_root = self.project_root / '..'
-            self.project_root = Path(os.path.abspath(self.project_root))
         else:
             self.project_root = Path(os.path.abspath(project_root))
         del project_root


### PR DESCRIPTION
This should fix bugs that happen after you do something like:
```python
os.chdir("<repository root path>")
install_hooks()
os.chdir("data-dir")
os.listdir(".")
```
Before this fix listdir() would return contents of the repo root and not data-dir