### PR TITLE
Use the last revision of the branch's remote on API requests

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -3,7 +3,6 @@ import io
 import os
 import re
 import subprocess
-import sys
 from configparser import ConfigParser
 from contextlib import contextmanager
 from functools import partial, wraps, lru_cache

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -164,28 +164,27 @@ class DagsHubFilesystem:
 
     @property
     def content_api_url(self):
-        content_api_path = f'/api/v1/repos{self.parsed_repo_url.path}/content/{self._current_revision}'
-        return self.parsed_repo_url._replace(path=content_api_path).geturl()
+        return self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/content/{self._current_revision}")
 
     @property
     def raw_api_url(self):
-        raw_api_path = f'/api/v1/repos{self.parsed_repo_url.path}/raw/{self._current_revision}'
-        return self.parsed_repo_url._replace(path=raw_api_path).geturl()
+        return self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/raw/{self._current_revision}")
 
     def is_commit_on_remote(self, sha1):
-        commit_api_path = f"/api/v1/repos{self.parsed_repo_url.path}/commits/{sha1}"
-        url = self.parsed_repo_url._replace(path=commit_api_path).geturl()
+        url = self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/commits/{sha1}")
         resp = requests.get(url, auth=self.auth)
         return resp.status_code == 200
 
     def get_remote_branch_head(self, branch):
-        branch_api_path = f"/api/v1/repos{self.parsed_repo_url.path}/branches/{branch}"
-        url = self.parsed_repo_url._replace(path=branch_api_path).geturl()
+        url = self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/branches/{branch}")
         resp = requests.get(url, auth=self.auth)
         if resp.status_code != 200:
             raise RuntimeError(f"Got status {resp.status_code} while trying to get head of branch {branch}. \r\n"
                                f"Response body: {resp.content}")
         return resp.json()["commit"]["id"]
+
+    def get_api_url(self, path):
+        return self.parsed_repo_url._replace(path=path).geturl()
 
     @property
     def auth(self):

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -147,7 +147,7 @@ class DagsHubFilesystem:
         if self.user_specified_branch:
             branch = self.user_specified_branch
         else:
-            with self.__open(self.project_root / ".git/HEAD") as head_file:
+            with open(self.project_root / ".git/HEAD") as head_file:
                 head = head_file.readline().strip()
             if head.startswith("ref"):
                 branch = head.split("/")[-1]
@@ -555,8 +555,6 @@ class dagshub_DirEntry:
 # Used for testing purposes only
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
-    if len(sys.argv) > 1:
-        os.chdir(sys.argv[1])
     fs = DagsHubFilesystem()
     fs.install_hooks()
 

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -79,7 +79,6 @@ class DagsHubFilesystem:
                  'username',
                  'password',
                  'dagshub_remotes',
-                 'branch_remotes',
                  'token',
                  '__weakref__')
 
@@ -110,7 +109,6 @@ class DagsHubFilesystem:
             self.project_root_fd = os.open(self.project_root, os.O_DIRECTORY)
 
         self.dagshub_remotes = []
-        self.branch_remotes = {}
         self.parse_git_config()
 
         if not repo_url:
@@ -223,15 +221,6 @@ class DagsHubFilesystem:
             remote = remote._replace(netloc=remote.hostname)
             remote = remote._replace(path=re.compile(r'(\.git)?/?$').sub('', remote.path))
             self.dagshub_remotes.append(remote.geturl())
-        # Build a dictionary of branch: path to remote's HEAD
-        for branch, branch_section in [(b, git_config[b]) for b in git_config if b.startswith("branch ")]:
-            branch_name = branch.split('"')[1]
-            remote_name = branch_section["remote"]
-            head_path = self.project_root / f".git/refs/remotes/{remote_name}/{branch_name}"
-            # Check that file exists. If it doesn't - then use the local branch's HEAD
-            if not os.path.exists(head_path):
-                head_path = self.project_root / f".git/refs/heads/{branch_name}"
-            self.branch_remotes[branch_name] = head_path
 
     def __del__(self):
         os.close(self.project_root_fd)


### PR DESCRIPTION
Now on each API request the client is opening two files:
- .git/HEAD to see what branch/revision we're on
- the HEAD of the remote for the associated branch

I'm not sure if trying to do some logic around caching them is a good idea