### PR TITLE
Open README with encoding param set to utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Should fix the issues with Windows users not being able to even install the package