### PR TITLE
Handle user trying to add a file to the DataSet more than once

### DIFF
--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -136,15 +136,18 @@ class Repo:
 
 class DataSet:
     def __init__(self, repo: Repo, directory):
-        self.files = []
+        self.files = {}
         self.repo = repo
         self.directory = directory
         self.request_url = self.repo.get_request_url(directory)
 
     def add(self, file: Union[str, IOBase], path=None):
-        file = self.get_file(file, path)
+        path, file = self.get_file(file, path)
         if file is not None:
-            self.files.append(file)
+            if path in self.files:
+                logger.warning(f"File already staged for upload on path \"{path}\". Overwriting")
+            self.files[path] = file
+
 
     @staticmethod
     def get_file(file: Union[str, IOBase], path=None):
@@ -161,7 +164,6 @@ class DataSet:
                 try:
                     f = open(file, 'rb')
                     return path, f
-                    return
                 except IsADirectoryError:
                     raise IsADirectoryError("'file' must describe a file, not a directory.")
 
@@ -172,10 +174,11 @@ class DataSet:
             raise e
 
     def _reset_dataset(self):
-        self.files = []
+        self.files.clear()
 
     def commit(self, commit_message=DEFAULT_COMMIT_MESSAGE, *args, **kwargs):
-        self.repo.upload_files(self.files, self.directory, commit_message=commit_message, *args, **kwargs)
+        file_list = list(self.files.items())
+        self.repo.upload_files(file_list, self.directory, commit_message=commit_message, *args, **kwargs)
         self._reset_dataset()
 
     def _get_last_commit(self):

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -146,7 +146,7 @@ class DataSet:
         if file is not None:
             if path in self.files:
                 logger.warning(f"File already staged for upload on path \"{path}\". Overwriting")
-            self.files[path] = file
+            self.files[path] = (path, file)
 
     @staticmethod
     def get_file(file: Union[str, IOBase], path=None):
@@ -176,7 +176,7 @@ class DataSet:
         self.files.clear()
 
     def commit(self, commit_message=DEFAULT_COMMIT_MESSAGE, *args, **kwargs):
-        file_list = list(self.files.items())
+        file_list = list(self.files.values())
         self.repo.upload_files(file_list, self.directory, commit_message=commit_message, *args, **kwargs)
         self._reset_dataset()
 

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -148,7 +148,6 @@ class DataSet:
                 logger.warning(f"File already staged for upload on path \"{path}\". Overwriting")
             self.files[path] = file
 
-
     @staticmethod
     def get_file(file: Union[str, IOBase], path=None):
         try:


### PR DESCRIPTION
I wanted to implement it with a `set()` first, but calling `open()` multiple time leads to different descriptors, hence different hashes for the resulting tuple of `(path, file)` 