### PR TITLE
Change `scandir` to behave like Python's 

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -345,28 +345,23 @@ class DagsHubFilesystem:
     def scandir(self, path='.'):
         path = Path(path)
         relative_path = self._relative_path(path)
-        if relative_path:
-            if self._passthrough_path(relative_path):
-                with self._open_fd(relative_path) as fd:
-                    return self.__scandir(fd)
-            else:
-                local_filenames = set()
-                try:
-                    with self._open_fd(relative_path) as fd:
-                        for direntry in self.__scandir(fd):
-                            local_filenames.add(direntry.name)
-                            yield direntry
-                    if relative_path == Path():
-                        if SPECIAL_FILE.name not in local_filenames:
-                            yield dagshub_DirEntry(self, path / SPECIAL_FILE, is_directory=False)
-                except FileNotFoundError:
-                    pass
-                resp = self._api_listdir(relative_path)
-                if resp.ok:
-                    for f in resp.json():
-                        name = Path(f['path']).name
-                        if name not in local_filenames:
-                            yield dagshub_DirEntry(self, path / name, f['type'] == 'dir')
+        if relative_path and not self._passthrough_path(relative_path):
+            local_filenames = set()
+            try:
+                for direntry in self.__scandir(path):
+                    local_filenames.add(direntry.name)
+                    yield direntry
+                if relative_path == Path():
+                    if SPECIAL_FILE.name not in local_filenames:
+                        yield dagshub_DirEntry(self, path / SPECIAL_FILE, is_directory=False)
+            except FileNotFoundError:
+                pass
+            resp = self._api_listdir(relative_path)
+            if resp.ok:
+                for f in resp.json():
+                    name = Path(f['path']).name
+                    if name not in local_filenames:
+                        yield dagshub_DirEntry(self, path / name, f['type'] == 'dir')
         else:
             return self.__scandir(path)
 

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -363,7 +363,8 @@ class DagsHubFilesystem:
                     if name not in local_filenames:
                         yield dagshub_DirEntry(self, path / name, f['type'] == 'dir')
         else:
-            return self.__scandir(path)
+            for entry in self.__scandir(path):
+                yield entry
 
     @cache_by_path
     def _api_listdir(self, path: str, include_size: bool = False):

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -294,7 +294,7 @@ class DagsHubFilesystem:
         else:
             return self.__stat(path, follow_symlinks=follow_symlinks)
 
-    def chdir(self, path):
+    def chdir(self, path: Union[PathLike, int]):
         relative_path = self._relative_path(path)
         if relative_path:
             abspath = os.path.join(self.project_root, relative_path)
@@ -311,7 +311,7 @@ class DagsHubFilesystem:
         else:
             self.__chdir(path)
 
-    def listdir(self, path='.'):
+    def listdir(self, path: Union[PathLike, int] = '.'):
         relative_path = self._relative_path(path)
         if relative_path:
             if self._passthrough_path(relative_path):
@@ -342,10 +342,10 @@ class DagsHubFilesystem:
             return self.__listdir(path)
 
     @wrapreturn(dagshub_ScandirIterator)
-    def scandir(self, path='.'):
-        path = Path(path)
+    def scandir(self, path: Union[PathLike, int] = '.'):
         relative_path = self._relative_path(path)
         if relative_path and not self._passthrough_path(relative_path):
+            path = Path(path)
             local_filenames = set()
             try:
                 for direntry in self.__scandir(path):


### PR DESCRIPTION
According to [PEP 0471](https://peps.python.org/pep-0471/) paths of `scandir()` entries should be basically `os.path.join(scandir_dir, name)`

Current behavior calls scandir on the relative_path, leading to incorrect paths in the resulting DirEntries.

Testcases for scandir are in following snippet. Saving it here so it doesn't get lost and will add it later when we add tests.
Folder structure for relevant parts being tested:
```
dir2
|-- .gitignore
|-- a.txt
|-- a.txt.dvc
`-- b.txt.dvc
```
b.txt is a dvc-tracked file that is deleted locally and is only on DagsHub

```python
import os
import unittest

from dagshub.streaming import DagsHubFilesystem

ORIGINAL_CWD = os.getcwd()
ORIGINAL_DIR = os.path.basename(ORIGINAL_CWD)
DVC_FILE = "b.txt"
DVC_DIR = "dir2"


class TestScanDir(unittest.TestCase):

    def setUp(self) -> None:
        self.maxDiff = None
        self.b_path = DVC_FILE
        os.chdir(ORIGINAL_CWD)
        self.fs = DagsHubFilesystem()

    def tearDown(self) -> None:
        os.chdir(ORIGINAL_CWD)
        self.fs.uninstall_hooks()

    def scandir_to_dict(self, scandir_iter):
        res = {}
        for f in scandir_iter:
            res[f.name] = f.path

        return res

    def get_dicts(self, path):
        expected = self.scandir_to_dict(os.scandir(path))
        self.fs.install_hooks()
        actual = self.scandir_to_dict(os.scandir(path))
        self.assertEqual(actual[DVC_FILE], self.b_path)
        del(actual[DVC_FILE])
        return expected, actual

    def test_local(self):
        path = DVC_DIR
        self.b_path = os.path.join(path, DVC_FILE)
        self.assertDictEqual(*self.get_dicts(path))

    def test_nested(self):
        os.chdir("..")
        path = f"{ORIGINAL_DIR}/{DVC_DIR}"
        self.b_path = os.path.join(path, DVC_FILE)
        self.assertDictEqual(*self.get_dicts(path))

    def test_up(self):
        path = f"../{ORIGINAL_DIR}/{DVC_DIR}"
        self.b_path = os.path.join(path, DVC_FILE)
        self.assertDictEqual(*self.get_dicts(path))

    def test_absolute(self):
        path = os.path.abspath(DVC_DIR)
        self.b_path = os.path.join(path, DVC_FILE)
        self.assertDictEqual(*self.get_dicts(path))


if __name__ == "__main__":
    unittest.main()
```