### PR TITLE
Make custom opener check less eager

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -245,7 +245,7 @@ class DagsHubFilesystem:
         # TODO Include more information in this file
         return b'v0\n'
 
-    def open(self, file: Union[PathLike, int], mode: str = 'r', opener=None, *args, **kwargs):
+    def open(self, file: Union[PathLike, int], mode: str = 'r', *args, opener=None, **kwargs):
         relative_path = self._relative_path(file)
         if relative_path:
             if opener is not None:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -244,10 +244,10 @@ class DagsHubFilesystem:
         return b'v0\n'
 
     def open(self, file: Union[PathLike, int], mode: str = 'r', opener=None, *args, **kwargs):
-        if opener is not None:
-            raise NotImplementedError('DagsHub\'s patched open() does not support custom openers')
         relative_path = self._relative_path(file)
         if relative_path:
+            if opener is not None:
+                raise NotImplementedError('DagsHub\'s patched open() does not support custom openers')
             project_root_opener = partial(os.open, dir_fd=self.project_root_fd)
             if self._passthrough_path(relative_path):
                 return self.__open(relative_path, mode, *args, **kwargs, opener=project_root_opener)
@@ -269,7 +269,7 @@ class DagsHubFilesystem:
                         #       check status code and only return FileNotFound on 404s
                         raise FileNotFoundError(f'Error finding {relative_path} in repo or on DagsHub')
         else:
-            return self.__open(file, mode, *args, **kwargs)
+            return self.__open(file, mode, *args, **kwargs, opener=opener)
 
     def stat(self, path: PathLike, *, dir_fd=None, follow_symlinks=True):
         if dir_fd is not None or not follow_symlinks:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -227,6 +227,8 @@ class DagsHubFilesystem:
     def _relative_path(self, file: Union[PathLike, int]):
         if isinstance(file, int):
             return None
+        if file == "":
+            return None
         path = os.path.abspath(file)
         try:
             rel = Path(path).relative_to(os.path.abspath(self.project_root))


### PR DESCRIPTION
The `file == ""` check fixes an issue preventing FastAI working in Notebooks, especially any display functions.

Basically fastprogress are updating on empty HTML (don't understand reason), which makes Jupyter check if it's a file.
And it does that using `os.stat`, so it tries to do a `os.stat("")`.
We could handle it ourselves, but imo `relative_path("")` returning `"."` is wrong behavior