### PR TITLE
Fixing open() function + Handle binary path arguments

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -261,7 +261,7 @@ class DagsHubFilesystem:
             else:
                 try:
                     return self.__open(relative_path, mode, *args, **kwargs, opener=project_root_opener)
-                except FileNotFoundError:
+                except FileNotFoundError as err:
                     if "r" in mode:
                         resp = self._api_download_file_git(relative_path)
                         if resp.ok:
@@ -281,8 +281,7 @@ class DagsHubFilesystem:
                             # Using the fact that stat creates tracked dirs
                             _ = self.stat(self.project_root / relative_path.parent)
                         except FileNotFoundError:
-                            raise FileNotFoundError(f"{relative_path.parent} does not exist on the filesystem "
-                                                    f"and is not a tracked directory")
+                            raise err
                         return self.__open(relative_path, mode, opener=project_root_opener)
 
         else:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -248,7 +248,7 @@ class DagsHubFilesystem:
 
     def open(self, file: Union[bytes, PathLike, int], mode: str = 'r', *args, opener=None, **kwargs):
         if type(file) is bytes:
-            file = file.decode("utf-8")
+            file = os.fsdecode(file)
         relative_path = self._relative_path(file)
         if relative_path:
             if opener is not None:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -279,7 +279,7 @@ class DagsHubFilesystem:
                     else:
                         try:
                             # Using the fact that stat creates tracked dirs
-                            _ = self.stat(relative_path.parent)
+                            _ = self.stat(self.project_root / relative_path.parent)
                         except FileNotFoundError:
                             raise FileNotFoundError(f"{relative_path.parent} does not exist on the filesystem "
                                                     f"and is not a tracked directory")
@@ -311,12 +311,15 @@ class DagsHubFilesystem:
                     if str(parent_path) not in self.remote_tree:
                         try:
                             # Run listdir to update cache
-                            self.listdir(parent_path)
+                            self.listdir(self.project_root / parent_path)
                         except FileNotFoundError:
                             raise err
 
                     cached_remote_parent_tree = self.remote_tree.get(str(parent_path))
                     logger.debug(f"cached_remote_parent_tree: {cached_remote_parent_tree}")
+
+                    if cached_remote_parent_tree is None:
+                        raise err
 
                     filetype = cached_remote_parent_tree.get(relative_path.name)
                     if filetype is None:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -246,7 +246,9 @@ class DagsHubFilesystem:
         # TODO Include more information in this file
         return b'v0\n'
 
-    def open(self, file: Union[PathLike, int], mode: str = 'r', *args, opener=None, **kwargs):
+    def open(self, file: Union[bytes, PathLike, int], mode: str = 'r', *args, opener=None, **kwargs):
+        if type(file) is bytes:
+            file = file.decode("utf-8")
         relative_path = self._relative_path(file)
         if relative_path:
             if opener is not None:


### PR DESCRIPTION
- Allow it to accept binary paths (allowed in python's docs + used by yolov5)
- Allow writing files inside of repository (+ creates directories if user's trying to write to a dvc-tracked nested dir not on disk)

NOTE: right now this is rebased on branch from #209 