### PR TITLE
Streaming: Add */site-packages/* to the passthrough path filter

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -245,8 +245,12 @@ class DagsHubFilesystem:
         except ValueError:
             return None
 
-    def _passthrough_path(self, relative_path: PathLike):
-        return str(relative_path).startswith(('.git/', '.dvc/'))
+    @staticmethod
+    def _passthrough_path(relative_path: PathLike):
+        str_path = str(relative_path)
+        if "/site-packages/" in str_path:
+            return True
+        return str_path.startswith(('.git/', '.dvc/'))
 
     def _special_file(self):
         # TODO Include more information in this file

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -250,7 +250,7 @@ class DagsHubFilesystem:
         str_path = str(relative_path)
         if "/site-packages/" in str_path:
             return True
-        return str_path.startswith(('.git/', '.dvc/'))
+        return str_path.startswith(('.git/', '.dvc/')) or str_path in (".git", ".dvc")
 
     def _special_file(self):
         # TODO Include more information in this file

--- a/tests/test_streaming_filesystem.py
+++ b/tests/test_streaming_filesystem.py
@@ -1,0 +1,20 @@
+import pytest
+from dagshub.streaming import DagsHubFilesystem
+from pathlib import Path
+
+
+@pytest.mark.parametrize("path,expected", [
+    ("regular/path/in/repo", False),
+    (".", False),
+    (".git/", True),
+    (".git/and/then/some", True),
+    (".dvc/", True),
+    (".dvc/and/then/some", True),
+    ("repo/file.dvc/", False),
+    ("repo/file.git/", False),
+    ("venv/lib/site-packages/some-package", True)
+])
+def test_passthrough_path(path, expected):
+    path = Path(path)
+    actual = DagsHubFilesystem._passthrough_path(path)
+    assert actual == expected


### PR DESCRIPTION
This should improve performance in use cases where the user has a venv inside of the project repository

Trying to look for modules inside of the project root takes a lot of time because of the fallback request to the server on a nonexistent file.

At the same time, I expect that a possibility of a user:
- having a site-packages folder in their repo/storing modules in a repository
- much more, having them in dvc and not in git
To be close to nil