### PR TITLE
DagsHubFilesystem: Move from requests to HTTPX

### DIFF
--- a/dagshub/common/config.py
+++ b/dagshub/common/config.py
@@ -16,6 +16,7 @@ TOKENS_CACHE_SCHEMA_VERSION = "1"
 DAGSHUB_USER_TOKEN_KEY = "DAGSHUB_USER_TOKEN"
 DAGSHUB_USERNAME_KEY = "DAGSHUB_USERNAME"
 DAGSHUB_PASSWORD_KEY = "DAGSHUB_PASSWORD"
+HTTP_TIMEOUT_KEY = "DAGSHUB_HTTP_TIMEOUT"
 
 parsed_host = urlparse(os.environ.get(HOST_KEY, DEFAULT_HOST))
 hostname = parsed_host.hostname
@@ -29,4 +30,5 @@ username = os.environ.get(DAGSHUB_USERNAME_KEY)
 password = os.environ.get(DAGSHUB_PASSWORD_KEY)
 custom_user_agent_suffix = f" dagshub-client-python/{__version__}"
 requests_headers = {"user-agent": requests.utils.default_user_agent() + custom_user_agent_suffix}
+http_timeout = os.environ.get(HTTP_TIMEOUT_KEY, 30)
 REPO_INFO_URL = "api/v1/repos/{owner}/{reponame}"

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -134,7 +134,7 @@ class DagsHubFilesystem:
         self.password = password or config.password
         self.token = token or config.token
 
-        self.http_client = httpx.Client(auth=self.auth)
+        self.http_client = httpx.Client(auth=self.auth, timeout=None)
 
         response = self._api_listdir('')
         if response.status_code < 400:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -75,6 +75,22 @@ SPECIAL_FILE = Path('.dagshub-streaming')
 
 # TODO: Singleton metaclass that lets us keep a "main" DvcFilesystem instance
 class DagsHubFilesystem:
+    """
+    A DagsHub-repo aware filesystem class
+
+    :param project_root: Path to the git repository with the repo.
+        If None, we look up the filesystem from the current dir until we find a git repo
+    :param repo_url: URL to the DagsHub repository.
+        If None, URL is received from the git configuration
+    :param branch: Explicitly sets a branch/commit revision to work with
+        If None, branch is received from the git configuration
+    :param username: DagsHub username
+    :param password: DagsHub password
+    :param token: DagsHub API token (as an alternative login variant to username/password)
+    :param timeout: Timeout in seconds for HTTP requests.
+        Influences all requests except for file download, which has no timeout
+    """
+
     __slots__ = ('project_root',
                  'project_root_fd',
                  'dvc_remote_url',
@@ -617,9 +633,28 @@ def install_hooks(project_root: Optional[PathLike] = None,
                   branch: Optional[str] = None,
                   username: Optional[str] = None,
                   password: Optional[str] = None,
+                  token: Optional[str] = None,
                   timeout: Optional[int] = None):
+    """
+    Monkey patches builtin Python functions to make them DagsHub-repo aware.
+    Patched functions are: `open()`, `os.listdir()`, `os.scandir()`, `os.stat()` + pathlib's functions that use them
+
+    This is equivalent to creating a `DagsHubFilesystem` object and calling its `install_hooks()` method
+
+    :param project_root: Path to the git repository with the repo.
+        If None, we look up the filesystem from the current dir until we find a git repo
+    :param repo_url: URL to the DagsHub repository.
+        If None, URL is received from the git configuration
+    :param branch: Explicitly sets a branch/commit revision to work with
+        If None, branch is received from the git configuration
+    :param username: DagsHub username
+    :param password: DagsHub password
+    :param token: DagsHub API token (as an alternative login variant to username/password)
+    :param timeout: Timeout in seconds for HTTP requests.
+        Influences all requests except for file download, which has no timeout
+    """
     fs = DagsHubFilesystem(project_root=project_root, repo_url=repo_url, branch=branch, username=username,
-                           password=password, timeout=timeout)
+                           password=password, token=token, timeout=timeout)
     fs.install_hooks()
 
 

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -85,7 +85,6 @@ class DagsHubFilesystem:
                  'password',
                  'dagshub_remotes',
                  'token',
-                 # 'http_client',
                  '__weakref__')
 
     def __init__(self,
@@ -133,8 +132,6 @@ class DagsHubFilesystem:
         self.username = username or config.username
         self.password = password or config.password
         self.token = token or config.token
-
-        # self.http_client = httpx.Client(auth=self.auth, timeout=None, follow_redirects=True)
 
         response = self._api_listdir('')
         if response.status_code < 400:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -514,8 +514,8 @@ class DagsHubFilesystem:
     @cache_by_path
     def _api_listdir(self, path: str, include_size: bool = False):
         return self.http_get(f'{self.content_api_url}/{path}',
-                         params={'include_size': 'true'} if include_size else {},
-                         headers=config.requests_headers)
+                             params={'include_size': 'true'} if include_size else {},
+                             headers=config.requests_headers)
 
     def _api_download_file_git(self, path: str):
         return self.http_get(f'{self.raw_api_url}/{path}', headers=config.requests_headers, timeout=None)

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -134,7 +134,7 @@ class DagsHubFilesystem:
         self.password = password or config.password
         self.token = token or config.token
 
-        self.http_client = httpx.Client(auth=self.auth, timeout=None)
+        self.http_client = httpx.Client(auth=self.auth, timeout=None, follow_redirects=True)
 
         response = self._api_listdir('')
         if response.status_code < 400:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ setuptools.setup(
         "fusepy>=3",
         "appdirs>=1.4.4",
         "pytimedinput>=2.0.1",
-        "click>=8.0.4"],
+        "click>=8.0.4",
+        "httpx>=0.22.0",
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This should improve the performance of streaming significantly.
Sadly have to use it without the Client object (Benchmark # 4), because it breaks on some multiprocessing usecases, specifically I noticed FastAI with workers had issues.

Benchmark data comparing to Requests, while querying n files from DagsHub (Average of 5 runs over office Wi-Fi).

```
Requests
	1:	1.80s
		Max:2.68s Min: 1.53s
	10:	12.09s
		Max:13.03s Min: 11.16s
	25:	32.60s
		Max:44.42s Min: 27.29s
HTTPX
	1:	0.57s
		Max:0.61s Min: 0.54s
	10:	3.95s
		Max:4.44s Min: 3.78s
	25:	9.16s
		Max:10.02s Min: 8.70s
HTTPX - HTTP2 (Caveat - load balancer communicates with backend in HTTP1.1)
	1:	0.66s
		Max:1.21s Min: 0.47s
	10:	4.00s
		Max:4.68s Min: 3.51s
	25:	8.97s
		Max:9.54s Min: 8.72s
HTTPX - no session
	1:	0.57s
		Max:0.64s Min: 0.54s
	10:	6.00s
		Max:6.16s Min: 5.74s
	25:	15.02s
		Max:15.21s Min: 14.78s
```