### PR TITLE
Fix uploads with path separators not working correctly on Windows

### DIFF
--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -465,7 +465,6 @@ class DataSet:
 
         return posixpath.normpath(directory)
 
-
     @staticmethod
     def get_file(file: Union[str, IOBase], path=None):
         """

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -1,4 +1,5 @@
 import json
+import posixpath
 
 import urllib
 import os
@@ -427,7 +428,7 @@ class DataSet:
         for root, dirs, files in os.walk(local_path):
             if len(files) > 0:
                 for filename in files:
-                    rel_file_path = os.posixpath.join(root, filename)
+                    rel_file_path = posixpath.join(root, filename)
                     rel_remote_file_path = rel_file_path.replace(local_path, "")
                     if (
                         glob_exclude == ""
@@ -462,7 +463,7 @@ class DataSet:
 
         """
 
-        return os.posixpath.normpath(directory)
+        return posixpath.normpath(directory)
 
 
     @staticmethod
@@ -483,8 +484,8 @@ class DataSet:
             # if path is not provided, fall back to the file name
             if path is None:
                 try:
-                    path = os.posixpath.basename(
-                        os.posixpath.normpath(file if type(file) is str else file.name)
+                    path = posixpath.basename(
+                        posixpath.normpath(file if type(file) is str else file.name)
                     )
                 except Exception:
                     raise RuntimeError(

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -427,7 +427,7 @@ class DataSet:
         for root, dirs, files in os.walk(local_path):
             if len(files) > 0:
                 for filename in files:
-                    rel_file_path = os.path.join(root, filename)
+                    rel_file_path = os.posixpath.join(root, filename)
                     rel_remote_file_path = rel_file_path.replace(local_path, "")
                     if (
                         glob_exclude == ""
@@ -462,7 +462,8 @@ class DataSet:
 
         """
 
-        return os.path.normpath(directory)
+        return os.posixpath.normpath(directory)
+
 
     @staticmethod
     def get_file(file: Union[str, IOBase], path=None):
@@ -482,8 +483,8 @@ class DataSet:
             # if path is not provided, fall back to the file name
             if path is None:
                 try:
-                    path = os.path.basename(
-                        os.path.normpath(file if type(file) is str else file.name)
+                    path = os.posixpath.basename(
+                        os.posixpath.normpath(file if type(file) is str else file.name)
                     )
                 except Exception:
                     raise RuntimeError(


### PR DESCRIPTION
We were using Python's `os.path`, that has os-dependent separators, when we should have used `posixpath`, because the paths sent to the server are POSIX.