### PR TITLE
Make the OAuth prompt more noticeable and prettier

### DIFF
--- a/dagshub/auth/oauth.py
+++ b/dagshub/auth/oauth.py
@@ -27,7 +27,7 @@ def oauth_flow(
     webbrowser.open(auth_link)
 
     rich_console.print("[bold]:exclamation::exclamation::exclamation: AUTHORIZATION REQUIRED "
-                  ":exclamation::exclamation::exclamation:[/bold]", justify="center")
+                       ":exclamation::exclamation::exclamation:[/bold]", justify="center")
     # Doing raw prints here because the rich syntax breaks in colab
     # Printing them line by line, because the link has to be its own print in order for Colab parser to correctly parse
     # the whole link

--- a/dagshub/auth/oauth.py
+++ b/dagshub/auth/oauth.py
@@ -4,7 +4,13 @@ import logging
 import urllib
 import uuid
 import httpx
+import rich.align
+import rich.padding
+import rich.status
+import webbrowser
+
 from dagshub.common import config
+from rich import print
 
 logger = logging.getLogger(__name__)
 
@@ -14,20 +20,27 @@ def oauth_flow(
     client_id: Optional[str] = None
 ) -> Dict:
 
-    host = host.strip("/")
-    dagshub_url = urllib.parse.urljoin(host, "login/oauth")
-    client_id = client_id or config.client_id
-    state = uuid.uuid4()
-    middle_man_request_id = hashlib.sha256(uuid.uuid4().bytes).hexdigest()
+    with rich.status.Status("Waiting for authorization:"):
+        host = host.strip("/")
+        dagshub_url = urllib.parse.urljoin(host, "login/oauth")
+        client_id = client_id or config.client_id
+        state = uuid.uuid4()
+        middle_man_request_id = hashlib.sha256(uuid.uuid4().bytes).hexdigest()
+        auth_link = f"{dagshub_url}/authorize?state={state}&client_id={client_id}" \
+                    f"&middleman_request_id={middle_man_request_id}"
 
-    link_prompt = f"Go to {dagshub_url}/authorize?state={state}&client_id={client_id}" \
-                  f"&middleman_request_id={middle_man_request_id} to authorize the client."
-    print(link_prompt)
+        webbrowser.open(auth_link)
 
-    res = httpx.post(
-        f"{dagshub_url}/middleman",
-        data={"request_id": middle_man_request_id}, timeout=None
-    )
+        print(rich.align.Align("[bold]:exclamation::exclamation::exclamation: AUTHORIZATION REQUIRED "
+                               ":exclamation::exclamation::exclamation:[/bold]", "center"))
+        link_prompt = rich.padding.Padding(f"Authorize the client by going to the following link:\n"
+                                           f"[link={auth_link}]{auth_link}[/link]", (2, 4))
+        print(link_prompt)
+
+        res = httpx.post(
+            f"{dagshub_url}/middleman",
+            data={"request_id": middle_man_request_id}, timeout=None
+        )
 
     if res.status_code != 200:
         raise Exception(

--- a/dagshub/common/__init__.py
+++ b/dagshub/common/__init__.py
@@ -1,0 +1,3 @@
+import rich.console
+
+rich_console = rich.console.Console()

--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -9,12 +9,11 @@ import zipfile
 import tarfile
 from http import HTTPStatus
 from urllib.parse import urlparse
-from rich import print
 
 import dagshub.auth
 import dagshub.common.logging
 from dagshub import init
-from dagshub.common import config
+from dagshub.common import config, rich_console
 from dagshub.upload import create_repo, Repo
 from dagshub.common.helpers import http_request, log_message
 from dagshub.upload.wrapper import add_dataset_to_repo, DEFAULT_DATA_DIR_NAME
@@ -91,10 +90,10 @@ def login(ctx, token, host, quiet):
     config.quiet = quiet or ctx.obj["quiet"]
     if token is not None:
         dagshub.auth.add_app_token(token, host)
-        print(":white_check_mark: Token added successfully")
+        rich_console.print(":white_check_mark: Token added successfully")
     else:
         dagshub.auth.add_oauth_token(host)
-        print(":white_check_mark: OAuth token added")
+        rich_console.print(":white_check_mark: OAuth token added")
 
 
 def validate_repo(ctx, param, value):

--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -9,6 +9,7 @@ import zipfile
 import tarfile
 from http import HTTPStatus
 from urllib.parse import urlparse
+from rich import print
 
 import dagshub.auth
 import dagshub.common.logging
@@ -90,10 +91,10 @@ def login(ctx, token, host, quiet):
     config.quiet = quiet or ctx.obj["quiet"]
     if token is not None:
         dagshub.auth.add_app_token(token, host)
-        print("Token added successfully")
+        print(":white_check_mark: Token added successfully")
     else:
         dagshub.auth.add_oauth_token(host)
-        print("OAuth token added")
+        print(":white_check_mark: OAuth token added")
 
 
 def validate_repo(ctx, param, value):

--- a/dagshub/common/helpers.py
+++ b/dagshub/common/helpers.py
@@ -5,8 +5,7 @@ from pathlib import Path
 
 import httpx
 
-from dagshub.common import config
-from rich import print
+from dagshub.common import config, rich_console
 
 default_logger = logging.getLogger("dagshub")
 
@@ -54,6 +53,6 @@ def log_message(msg, logger=None):
     Logs message to the info of the logger + prints, unless the printing was suppressed
     """
     if not config.quiet:
-        print(msg)
+        rich_console.print(msg)
     logger = logger or default_logger
     logger.info(msg)

--- a/dagshub/common/helpers.py
+++ b/dagshub/common/helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import httpx
 
 from dagshub.common import config
+from rich import print
 
 default_logger = logging.getLogger("dagshub")
 

--- a/dagshub/streaming/__init__.py
+++ b/dagshub/streaming/__init__.py
@@ -1,4 +1,3 @@
-from rich import print
 from .filesystem import DagsHubFilesystem, install_hooks, uninstall_hooks
 
 try:

--- a/dagshub/streaming/__init__.py
+++ b/dagshub/streaming/__init__.py
@@ -1,3 +1,4 @@
+from rich import print
 from .filesystem import DagsHubFilesystem, install_hooks, uninstall_hooks
 
 try:

--- a/dagshub/streaming/mount.py
+++ b/dagshub/streaming/mount.py
@@ -8,6 +8,7 @@ from os import PathLike
 from pathlib import Path
 from threading import Lock
 from typing import Optional
+from rich import print
 
 from .filesystem import SPECIAL_FILE, DagsHubFilesystem
 

--- a/dagshub/streaming/mount.py
+++ b/dagshub/streaming/mount.py
@@ -8,7 +8,7 @@ from os import PathLike
 from pathlib import Path
 from threading import Lock
 from typing import Optional
-from rich import print
+from dagshub.common import rich_console
 
 from .filesystem import SPECIAL_FILE, DagsHubFilesystem
 
@@ -116,7 +116,7 @@ def mount(debug=False,
     logging.basicConfig(level=logging.DEBUG)
     fuse = DagsHubFUSE(project_root=project_root, repo_url=repo_url, branch=branch, username=username,
                        password=password, token=token)
-    print(
+    rich_console.print(
         f'Mounting DagsHubFUSE filesystem at {fuse.fs.project_root}\n'
         f'Run `cd .` in any existing terminals to utilize mounted FS.')
     FUSE(fuse, str(fuse.fs.project_root), foreground=debug, nonempty=True)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         "click>=8.0.4",
         "httpx==0.22.0",
         "GitPython>=3.1.29",
+        "rich~=13.1.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
         "click>=8.0.4",
         "httpx==0.22.0",
         "GitPython>=3.1.29",
-        "rich~=13.1.0",
+        "rich[jupyter]~=13.1.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Also we now open the authorization link using `webbrowser.open` which should work everywhere
This PR introduces [rich](https://github.com/Textualize/rich) as a dependency, opening way to prettify other prompts later down the line.

Example of the new prompt (censored in post):
![image](https://user-images.githubusercontent.com/111061261/212897024-f683b614-73cd-4d2d-b739-242c6386e86f.png)

Tested platforms:
- Colab - Code Cell, Bash execution using `!`
- Mac - iTerm, IntelliJ Terminal, IntelliJ Run
- Windows - cmd, VSCode Terminal