### PR TITLE
Allow uploading folders via dagshub upload from CLI

### DIFF
--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 import dagshub.auth
 import dagshub.common.logging
-from dagshub import init
+from dagshub import init, __version__
 from dagshub.common import config, rich_console
 from dagshub.upload import create_repo, Repo
 from dagshub.common.helpers import http_request, log_message
@@ -59,6 +59,9 @@ def mount(ctx, verbose, quiet, **kwargs):
 @cli.group()
 @click.pass_context
 def setup(ctx):
+    """
+    Initialize additional functionality in the current repository
+    """
     pass
 
 
@@ -70,6 +73,9 @@ def setup(ctx):
 @click.option("-q", "--quiet", is_flag=True, help="Suppress print output")
 @click.pass_context
 def setup_dvc(ctx, quiet, repo_name, repo_owner, url, host):
+    """
+    Initialize dvc
+    """
     host = host or ctx.obj["host"]
     config.quiet = quiet or ctx.obj["quiet"]
     init(repo_name=repo_name, repo_owner=repo_owner, url=url, root=None, host=host, mlflow=False, dvc=True)
@@ -148,6 +154,14 @@ def upload(ctx,
     owner, repo_name = repo
     repo = Repo(owner=owner, name=repo_name, branch=branch)
     repo.upload(file=filename, path=target, commit_message=message, force=update)
+
+
+@cli.command()
+def version():
+    """
+    Prints the current installed version of the DagsHub client
+    """
+    print(__version__)
 
 
 @cli.group()

--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -26,7 +26,7 @@ from dagshub.upload.wrapper import add_dataset_to_repo, DEFAULT_DATA_DIR_NAME
 @click.pass_context
 def cli(ctx, host, quiet):
     dagshub.common.logging.init_logger()
-    ctx.obj = {"host": host.strip("/"), "quiet": quiet}
+    ctx.obj = {"host": host.strip("/"), "quiet": quiet or config.quiet}
 
 
 @cli.command()

--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -154,7 +154,7 @@ def upload(ctx,
 
     owner, repo_name = repo
     repo = Repo(owner=owner, name=repo_name, branch=branch)
-    repo.upload(file=filename, path=target, commit_message=message, force=update)
+    repo.upload(local_path=filename, remote_path=target, commit_message=message, force=update)
 
 
 @cli.command()

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -434,7 +434,7 @@ class DataSet:
 
         progress = rich.progress.Progress(rich.progress.SpinnerColumn(), *rich.progress.Progress.get_default_columns(),
                                           console=rich_console, transient=True, disable=config.quiet)
-        total_task = progress.add_task(f"Uploading files...")
+        total_task = progress.add_task("Uploading files...")
 
         with progress:
             for root, dirs, files in os.walk(local_path):

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -172,9 +172,9 @@ class Repo:
 
     def upload(
         self,
-        file: Union[str, IOBase],
+        local_path: Union[str, IOBase],
         commit_message=DEFAULT_COMMIT_MESSAGE,
-        path=None,
+        remote_path=None,
         **kwargs,
     ):
         """
@@ -189,8 +189,12 @@ class Repo:
         :return: None
 
         """
-        file_for_upload = DataSet.get_file(file, path)
-        self.upload_files([file_for_upload], commit_message=commit_message, **kwargs)
+        if os.path.isdir(local_path):
+            dir_to_upload = self.directory(remote_path)
+            dir_to_upload.add_dir(local_path)
+        else:
+            file_to_upload = DataSet.get_file(local_path, remote_path)
+            self.upload_files([file_to_upload], commit_message=commit_message, **kwargs)
 
     def upload_files(
         self,

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -19,6 +19,7 @@ from dagshub.common.helpers import log_message
 # todo: handle api urls in common package
 CONTENT_UPLOAD_URL = "api/v1/repos/{owner}/{reponame}/content/{branch}/{path}"
 DEFAULT_COMMIT_MESSAGE = "Upload files using DagsHub client"
+DEFAULT_DATASET_COMMIT_MESSAGE = "Initial dataset commit"
 REPO_CREATE_URL = "api/v1/user/repos"
 ORG_REPO_CREATE_URL = "api/v1/org/{orgname}/repos"
 USER_INFO_URL = "api/v1/user"
@@ -43,7 +44,7 @@ def create_dataset(repo_name, local_path, glob_exclude="", org_name="", private=
     """
     repo = create_repo(repo_name, org_name=org_name, private=private)
     dir = repo.directory(repo_name)
-    dir.add_dir(local_path, glob_exclude, commit_message="Initial dataset commit")
+    dir.add_dir(local_path, glob_exclude, commit_message=DEFAULT_DATASET_COMMIT_MESSAGE)
     return repo
 
 
@@ -57,7 +58,7 @@ def add_dataset_to_repo(repo,
     :param data_dir (str): name of data directory that will be created inside repo
     """
     dir = repo.directory(data_dir)
-    dir.add_dir(local_path, commit_message="Initial dataset commit")
+    dir.add_dir(local_path, commit_message=DEFAULT_DATASET_COMMIT_MESSAGE)
 
 
 def create_repo(

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -235,7 +235,7 @@ class Repo:
         if force:
             data["last_commit"] = self._get_last_commit()
 
-        log_message(f'Uploading {len(files)} files to "{self.full_name}"...', logger)
+        log_message(f'Uploading files ({len(files)}) to "{self.full_name}"...', logger)
         res = s.put(
             self.get_request_url(directory_path),
             data=data,

--- a/docs/index.md
+++ b/docs/index.md
@@ -170,7 +170,8 @@ from dagshub.upload import Repo
 repo = Repo("<repo_owner>", "<repo_name>")  # Optional: username, password, token, branch
 
 # Upload a single file to a repository in one line
-repo.upload(file="<local_file_path>", path="<path_in_remote>", versioning=”dvc”)  # Optional: versioning, new_branch, commit_message
+repo.upload(local_path="<local_file_path>", remote_path="<path_in_remote>",
+            versioning=”dvc”)  # Optional: versioning, new_branch, commit_message
 ```
 
 This will upload a single file to DagsHub, which will be tracked by DVC.


### PR DESCRIPTION
This also allows the regular `repo.upload` function to upload folders and not just files.
Also along the way added a prettier progress bar for uploading the folder, that shows some progress to the user.
And also the commit message for uploading directories/datasets is now a bit better

Tested in Colab, the progress bar doesn't show up there, but the prints with "Uploading x files" still show up, so I consider that ok