### PR TITLE
Make --update work with uploading folders

### DIFF
--- a/dagshub/common/helpers.py
+++ b/dagshub/common/helpers.py
@@ -36,6 +36,10 @@ def http_request(method, url, **kwargs):
     for arg in mixin_args:
         if arg not in kwargs:
             kwargs[arg] = mixin_args[arg]
+    # Add the config headers to the headers being sent out
+    headers = kwargs.get("headers", {})
+    headers.update(config.requests_headers)
+    kwargs["headers"] = headers
     return httpx.request(method, url, **kwargs)
 
 

--- a/dagshub/upload/errors.py
+++ b/dagshub/upload/errors.py
@@ -1,4 +1,3 @@
-import functools
 from dataclasses import dataclass
 
 import httpx
@@ -18,9 +17,9 @@ class GenericAPIErrorContent:
 _error_lookup = {}
 
 
-def _error_name(error: str):
+def register_upload_api_error(error_value: str):
     def decorator(cls):
-        _error_lookup[error] = cls
+        _error_lookup[error_value] = cls
 
         def __init__(self, details: str):
             self.details = details
@@ -29,32 +28,32 @@ def _error_name(error: str):
     return decorator
 
 
-@_error_name("missing last_commit")
+@register_upload_api_error(error_value="missing last_commit")
 class UpdateNotAllowedError(Exception):
     pass
 
 
-@_error_name("invalid last_commit")
+@register_upload_api_error(error_value="invalid last_commit")
 class InvalidLastCommitError(Exception):
     pass
 
 
-@_error_name("versioning conflict")
+@register_upload_api_error(error_value="versioning conflict")
 class VersioningConflictError(Exception):
     pass
 
 
-@_error_name("edit pipeline unsupported")
+@register_upload_api_error(error_value="edit pipeline unsupported")
 class UnsupportedStageContainerFileError(Exception):
     pass
 
 
-@_error_name("path conflict")
+@register_upload_api_error(error_value="path conflict")
 class PathConflictError(Exception):
     pass
 
 
-@_error_name("server error")
+@register_upload_api_error(error_value="server error")
 class InternalServerErrorError(Exception):
     pass
 
@@ -68,7 +67,7 @@ class DagsHubAPIError(Exception):
         self.message = message
 
 
-def determine_error(response: httpx.Response) -> Exception:
+def determine_upload_api_error(response: httpx.Response) -> Exception:
     try:
         json_content = response.json()
     except Exception as e:

--- a/dagshub/upload/errors.py
+++ b/dagshub/upload/errors.py
@@ -1,0 +1,87 @@
+import functools
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass
+class UploadErrorResponseContent:
+    error: str
+    details: str
+
+
+@dataclass
+class GenericAPIErrorContent:
+    message: str
+
+
+_error_lookup = {}
+
+
+def _error_name(error: str):
+    def decorator(cls):
+        _error_lookup[error] = cls
+
+        def __init__(self, details: str):
+            self.details = details
+        cls.__init__ = __init__
+        return cls
+    return decorator
+
+
+@_error_name("missing last_commit")
+class UpdateNotAllowedError(Exception):
+    pass
+
+
+@_error_name("invalid last_commit")
+class InvalidLastCommitError(Exception):
+    pass
+
+
+@_error_name("versioning conflict")
+class VersioningConflictError(Exception):
+    pass
+
+
+@_error_name("edit pipeline unsupported")
+class UnsupportedStageContainerFileError(Exception):
+    pass
+
+
+@_error_name("path conflict")
+class PathConflictError(Exception):
+    pass
+
+
+@_error_name("server error")
+class InternalServerErrorError(Exception):
+    pass
+
+
+class DagsHubAPIError(Exception):
+    """
+    Generic API Exception, only has a message
+    """
+    def __init__(self, message: str):
+        super().__init__()
+        self.message = message
+
+
+def determine_error(response: httpx.Response) -> Exception:
+    try:
+        json_content = response.json()
+    except Exception as e:
+        return e
+
+    if "error" in json_content and "details" in json_content:
+        error_content = UploadErrorResponseContent(json_content["error"], json_content["details"])
+        error_class = _error_lookup.get(error_content.error)
+        if error_class is None:
+            return DagsHubAPIError(f"{error_content.error}:\n{error_content.details}")
+        return error_class(error_content.details)
+
+    elif "message" in json_content:
+        return DagsHubAPIError(json_content["message"])
+
+    return RuntimeError(response.content)

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -14,7 +14,7 @@ from dagshub.common import config, helpers, rich_console
 from http import HTTPStatus
 import dagshub.auth
 from dagshub.auth.token_auth import HTTPBearerAuth
-from dagshub.upload.errors import determine_error
+from dagshub.upload.errors import determine_upload_api_error
 from dagshub.common.helpers import log_message
 
 # todo: handle api urls in common package
@@ -274,7 +274,7 @@ class Repo:
         )
 
         if res.status_code != HTTPStatus.OK:
-            raise determine_error(res)
+            raise determine_upload_api_error(res)
         else:
             log_message("Upload finished successfully!", logger)
 
@@ -440,7 +440,7 @@ class DataSet:
                 if commit_message is None:
                     commit_message = upload_kwargs.get("commit_message", f"Commit data points in folder {root}")
                 if "commit_message" in upload_kwargs:
-                    del(upload_kwargs["commit_message"])
+                    del upload_kwargs["commit_message"]
 
                 if len(files) > 0:
                     for filename in files:

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -14,6 +14,7 @@ from dagshub.common import config, helpers, rich_console
 from http import HTTPStatus
 import dagshub.auth
 from dagshub.auth.token_auth import HTTPBearerAuth
+from dagshub.upload.errors import determine_error
 from dagshub.common.helpers import log_message
 
 # todo: handle api urls in common package
@@ -194,7 +195,7 @@ class Repo:
         """
         if os.path.isdir(local_path):
             dir_to_upload = self.directory(remote_path)
-            dir_to_upload.add_dir(local_path, commit_message=commit_message)
+            dir_to_upload.add_dir(local_path, commit_message=commit_message, **kwargs)
         else:
             file_to_upload = DataSet.get_file(local_path, remote_path)
             self.upload_files([file_to_upload], commit_message=commit_message, **kwargs)
@@ -255,7 +256,7 @@ class Repo:
     def _log_upload_details(self, data, res, files):
         """
         The _log_upload_details function logs the request URL, data, and files.
-        It then logs the response status code and content. If the response is not 200(OK), it will log an error message.
+        It then logs the response status code and content. If the response is not 200(OK), it raises an error.
 
 
 
@@ -271,17 +272,10 @@ class Repo:
             f"Data:\n{json.dumps(data, indent=4)}\n"
             f"Files:\n{json.dumps(list(map(str, files)), indent=4)}"
         )
-        try:
-            content = json.dumps(res.json(), indent=4)
-        except Exception:
-            content = res.content.decode("utf-8")
 
         if res.status_code != HTTPStatus.OK:
-            raise RuntimeError(f"Response ({res.status_code}):\n" f"{content}")
+            raise determine_error(res)
         else:
-            logger.debug(f"Response ({res.status_code})\n")
-
-        if res.status_code == 200:
             log_message("Upload finished successfully!", logger)
 
     @property
@@ -418,15 +412,17 @@ class DataSet:
                 )
             self.files[path] = (path, file)
 
-    def add_dir(self, local_path, glob_exclude="", commit_message=None):
+    def add_dir(self, local_path, glob_exclude="", commit_message=None, **upload_kwargs):
         """
-        The add_dir function adds an entire directory to a DagsHub repository.
+        The add_dir function adds an entire dvc directory to a DagsHub repository.
         It does this by iterating through all the files in the given directory and uploading them one-by-one.
         The function also commits all of these changes at once, so as not to overload the API with requests.
 
 
         :param local_path  (str): Specify the local path where the dataset to upload is located
         :param glob_exclude (str): Exclude certain files from the upload process
+        :param commit_message (str): Commit message
+        :param upload_kwargs (dict): kwargs that are passed to the uploading function
         :return: None
 
         """
@@ -442,7 +438,9 @@ class DataSet:
                 folder_task = progress.add_task(f"Uploading files from {root}", total=len(files))
 
                 if commit_message is None:
-                    commit_message = f"Commit data points in folder {root}"
+                    commit_message = upload_kwargs.get("commit_message", f"Commit data points in folder {root}")
+                if "commit_message" in upload_kwargs:
+                    del(upload_kwargs["commit_message"])
 
                 if len(files) > 0:
                     for filename in files:
@@ -455,12 +453,12 @@ class DataSet:
                             self.add(file=rel_file_path, path=rel_remote_file_path)
                             if len(self.files) > 49:
                                 file_counter += len(self.files)
-                                self.commit(commit_message, versioning="dvc")
+                                self.commit(commit_message, versioning="dvc", **upload_kwargs)
                                 progress.update(folder_task, advance=len(self.files))
                                 progress.update(total_task, completed=file_counter)
                     if len(self.files) > 0:
                         file_counter += len(self.files)
-                        self.commit(commit_message, versioning="dvc")
+                        self.commit(commit_message, versioning="dvc", **upload_kwargs)
                         progress.update(total_task, completed=file_counter)
                 progress.remove_task(folder_task)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,10 +1,9 @@
 import httpx
 
-from dagshub.upload.errors import determine_error, UpdateNotAllowedError
+from dagshub.upload.errors import determine_upload_api_error, UpdateNotAllowedError
 
 
 def test_determine_error():
     resp = httpx.Response(400, content='{"error": "missing last_commit", "details": "file exist"}')
-    err = determine_error(resp)
+    err = determine_upload_api_error(resp)
     assert isinstance(err, UpdateNotAllowedError)
-

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,10 @@
+import httpx
+
+from dagshub.upload.errors import determine_error, UpdateNotAllowedError
+
+
+def test_determine_error():
+    resp = httpx.Response(400, content='{"error": "missing last_commit", "details": "file exist"}')
+    err = determine_error(resp)
+    assert isinstance(err, UpdateNotAllowedError)
+


### PR DESCRIPTION
I've also introduced error-handling for backend's API responses, so we can handle errors better in the future, instead of throwing stack traces.

The `--update` fix already utilizes this error handling to provide user with actionable feedback if they made an error, instead of saying "no last_commit specified". 

<img width="805" alt="image" src="https://user-images.githubusercontent.com/111061261/215318305-09423c1b-9502-4bc0-9184-8b46f5373772.png">
