### PR TITLE
Bug/close files after upload

### DIFF
--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -5,7 +5,7 @@ import urllib
 import os
 import logging
 import fnmatch
-from typing import Union
+from typing import Union, Tuple, BinaryIO, Dict
 from io import IOBase
 import httpx
 from dagshub.common import config, helpers
@@ -387,7 +387,7 @@ class DataSet:
 
         """
 
-        self.files = {}
+        self.files: Dict[os.PathLike, Tuple[os.PathLike, BinaryIO]] = {}
         self.repo = repo
         self.directory = self._clean_directory_name(directory)
         self.request_url = self.repo.get_request_url(directory)
@@ -467,15 +467,14 @@ class DataSet:
         return posixpath.normpath(directory)
 
     @staticmethod
-    def get_file(file: Union[str, IOBase], path=None):
+    def get_file(file: Union[str, IOBase], path: os.PathLike=None) -> Tuple[os.PathLike, BinaryIO]:
         """
         The get_file function is a helper function that takes in either a string or an IOBase object and returns
         a tuple containing the file's name and the file itself. If no path is provided, it will default to the name of
         the file.
 
-        :param file (str):Union[str: Specify the file that you want to upload
-        :param IOBase]: Handle both file paths and file objects
-        :param path (str): Specify the path of the file
+        :param file (Union[str, IOBase]): File to upload
+        :param path (str): Desired path of the file in the repository
         :return: A tuple of the path and a file object
 
         """
@@ -505,7 +504,7 @@ class DataSet:
 
         except Exception as e:
             logger.error(e)
-            raise e
+            raise
 
     def _reset_dataset(self):
         """
@@ -513,7 +512,11 @@ class DataSet:
 
         :return: None
         """
-
+        for f in self.files.values():
+            try:
+                f[1].close()
+            except Exception as e:
+                logger.warning(f"Error closing file {f[0]}: {e}")
         self.files.clear()
 
     def commit(self, commit_message=DEFAULT_COMMIT_MESSAGE, *args, **kwargs):

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -467,7 +467,7 @@ class DataSet:
         return posixpath.normpath(directory)
 
     @staticmethod
-    def get_file(file: Union[str, IOBase], path: os.PathLike=None) -> Tuple[os.PathLike, BinaryIO]:
+    def get_file(file: Union[str, IOBase], path: os.PathLike = None) -> Tuple[os.PathLike, BinaryIO]:
         """
         The get_file function is a helper function that takes in either a string or an IOBase object and returns
         a tuple containing the file's name and the file itself. If no path is provided, it will default to the name of

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -47,12 +47,46 @@ class MockApi(MockRouter):
 
     def _default_endpoints_and_responses(self):
         endpoints = {
+            "repo": rf"{BASE_REGEX}/?",
             "branch": rf"{BASE_REGEX}/branches/\w+",
             "branches": rf"{BASE_REGEX}/branches",
             "list_root": rf"{BASE_REGEX}/content/{self.current_revision}/$",
         }
 
         responses = {
+            "repo": Response(
+                200,
+                json={
+                    "id": 713,
+                    "owner": {
+                        "id": 736,
+                        "login": self.user,
+                        "full_name": self.user,
+                        "avatar_url": "https://dagshub.com/avatars/736",
+                        "username": self.user,
+                    },
+                    "name": self.reponame,
+                    "full_name": self.repourlpath,
+                    "description": "Open Source Data Science (OSDS) Monocular Depth Estimation – Turn 2d photos into 3d photos – show your grandma the awesome results.",
+                    "private": False,
+                    "fork": False,
+                    "parent": None,
+                    "empty": False,
+                    "mirror": False,
+                    "size": 19987456,
+                    "html_url": f"https://dagshub.com/{self.repourlpath}",
+                    "clone_url": f"https://dagshub.com/{self.repourlpath}.git",
+                    "website": "",
+                    "stars_count": 12,
+                    "forks_count": 25,
+                    "watchers_count": 5,
+                    "open_issues_count": 6,
+                    "default_branch": "main",
+                    "created_at": "2020-08-02T15:19:07Z",
+                    "updated_at": "2023-02-01T16:06:44Z",
+                    "permissions": {"admin": False, "push": False, "pull": False},
+                },
+            ),
             "branch": Response(
                 200,
                 json={

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -47,7 +47,7 @@ class MockApi(MockRouter):
 
     def _default_endpoints_and_responses(self):
         endpoints = {
-            "repo": rf"{BASE_REGEX}/?",
+            "repo": rf"/api/v1/repos/{self.repourlpath}/?$",
             "branch": rf"{BASE_REGEX}/branches/\w+",
             "branches": rf"{BASE_REGEX}/branches",
             "list_root": rf"{BASE_REGEX}/content/{self.current_revision}/$",
@@ -67,7 +67,8 @@ class MockApi(MockRouter):
                     },
                     "name": self.reponame,
                     "full_name": self.repourlpath,
-                    "description": "Open Source Data Science (OSDS) Monocular Depth Estimation – Turn 2d photos into 3d photos – show your grandma the awesome results.",
+                    "description": "Open Source Data Science (OSDS) Monocular Depth Estimation "
+                    "– Turn 2d photos into 3d photos – show your grandma the awesome results.",
                     "private": False,
                     "fork": False,
                     "parent": None,
@@ -200,10 +201,17 @@ class MockApi(MockRouter):
         route.mock(Response(status, json=content))
         return route
 
-    def generate_list_entry(self, path, type="file"):
+    def enable_uploads(self):
+        route = self.put(
+            name="upload", url__regex=f"api/v1/repos/{self.repourlpath}/content/main/.*"
+        )
+        route.mock(Response(200))
+        return route
+
+    def generate_list_entry(self, path, entry_type="file"):
         return {
             "path": path,
-            "type": type,
+            "type": entry_type,
             "size": 0,
             "hash": "8586da76f372efa83d832a9d0e664817.dir",
             "versioning": "dvc",

--- a/tests/dda/upload/conftest.py
+++ b/tests/dda/upload/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from dagshub.upload import Repo
+
+
+@pytest.fixture
+def upload_repo(repouser, reponame, mock_api):
+    repo = Repo(repouser, reponame)
+    yield repo

--- a/tests/dda/upload/conftest.py
+++ b/tests/dda/upload/conftest.py
@@ -5,5 +5,6 @@ from dagshub.upload import Repo
 
 @pytest.fixture
 def upload_repo(repouser, reponame, mock_api):
+    mock_api.enable_uploads()
     repo = Repo(repouser, reponame)
     yield repo

--- a/tests/dda/upload/test_wrapper.py
+++ b/tests/dda/upload/test_wrapper.py
@@ -1,0 +1,26 @@
+import os
+import uuid
+
+import pytest
+
+from dagshub.upload import Repo
+
+
+@pytest.fixture(scope="function")
+def test_file():
+    filepath = f"{uuid.uuid4()}.txt"
+    with open(filepath, "w") as f:
+        f.write("test data")
+    yield filepath
+    try:
+        os.remove(filepath)
+    except OSError:
+        pass
+
+
+def test_upload_dataset_closes_files(upload_repo: Repo, test_file: str):
+    ds = upload_repo.directory("subdir")
+    file_handle = open(test_file)
+    ds.add(file_handle, "filepath.txt")
+    ds.commit()
+    assert file_handle.closed


### PR DESCRIPTION
If you add files to a dataset upload via `ds.add`, they are not closed after user does `ds.commit` to add them.
This is a problem on windows, where opening any file is exclusive. 
So if a user is uploading "temporary" output to their repo, for example:

```python
with open("out/model-output.txt", "w") as f:
  f.write("Very cool model")

repo = Repo("user", "repo")
ds = repo.directory()
ds.add("out/model-output.txt", "model-output-today.txt")
ds.commit("Added model output")

os.remove("out/model-output.txt")
```

The script crashes on the remove, since the file is still opened by the DataSet.

[Originally raised by Mark in Discord](https://discord.com/channels/698874030052212737/705302775784800278/1074278169672155146)

Caveat: now we close ALL files, even if user explicitly used `ds.add()` to add an IOBase and not a path.
I don't think this is a problem. We don't seek back on the passed IOBase anyway, so it's gonna be seeked to its end. Shouldn't be a big problem that it's closed now.