### PR TITLE
Bug - listdir cache doesn't get invalidated in DDA Streaming after uninstall_hooks

### DIFF
--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -136,7 +136,8 @@ def upload(ctx,
            host,
            **kwargs):
     """
-    Upload FILENAME to REPO at location TARGET [Unlike git push, we upload your data to DagsHub once and don't sync the repo state]
+    Upload FILENAME to REPO at location TARGET
+    [Unlike git push, we upload your data to DagsHub once and don't sync the repo state]
     REPO should be of the form <owner>/<repo-name>, i.e nirbarazida/yolov6.
     TARGET should include the full path inside the repo, including the filename itself.
     """
@@ -162,7 +163,7 @@ def repo():
 @repo.command()
 @click.argument("repo_name")
 @click.option("-u", "--upload-data", help="Upload data from specified url to new repository")
-@click.option("-c", "--clone", is_flag=True,  help="Clone repository locally")
+@click.option("-c", "--clone", is_flag=True, help="Clone repository locally")
 @click.option("-v", "--verbose", default=0, count=True, help="Verbosity level")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress print output")
 @click.pass_context

--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -136,7 +136,7 @@ def upload(ctx,
            host,
            **kwargs):
     """
-    Upload FILENAME to REPO at location TARGET.
+    Upload FILENAME to REPO at location TARGET [Unlike git push, we upload your data to DagsHub once and don't sync the repo state]
     REPO should be of the form <owner>/<repo-name>, i.e nirbarazida/yolov6.
     TARGET should include the full path inside the repo, including the filename itself.
     """

--- a/dagshub/common/helpers.py
+++ b/dagshub/common/helpers.py
@@ -42,8 +42,8 @@ def http_request(method, url, **kwargs):
 def get_project_root(root):
     while not (root / '.git').is_dir():
         if ismount(root):
-            raise ValueError('No git project found! (stopped at mountpoint {root}). \
-                             Please run this command in a git repository.')
+            raise ValueError(f"No git project found! (stopped at mountpoint {root}). \
+                               Please run this command in a git repository.")
         root = root / '..'
     return Path(root)
 

--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -19,8 +19,8 @@ def init(repo_name=None, repo_owner=None, url=None, root=None,
     if dvc:
         root = root or get_project_root(Path(os.path.abspath('.')))
         if not exists(root / '.git'):
-            raise ValueError('No git project found! (stopped at mountpoint {root}). \
-                              Please run this command in a git repository.')
+            raise ValueError(f'No git project found! (stopped at mountpoint {root}). \
+                               Please run this command in a git repository.')
 
     if url and (repo_name or repo_owner):
         repo_name, repo_owner = None, None

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -390,7 +390,6 @@ class DataSet:
         self.files: Dict[os.PathLike, Tuple[os.PathLike, BinaryIO]] = {}
         self.repo = repo
         self.directory = self._clean_directory_name(directory)
-        self.request_url = self.repo.get_request_url(directory)
 
     def add(self, file: Union[str, IOBase], path=None):
         """


### PR DESCRIPTION
Repro snippet (needs to have an empty `./subfolder/` dir to mount the repo into):
```python
import os
from dagshub.streaming import install_hooks, uninstall_hooks


def list_repo(url):
    install_hooks(repo_url=url, project_root="subfolder/")
    print(list(os.listdir("subfolder/")))
    uninstall_hooks()
    
    
repos = [
    "https://dagshub.com/OperationSavta/SavtaDepth",
    "https://dagshub.com/nirbarazida/CheXNet"
]
for repo in repos:
    list_repo(repo)
```

Expected return (different files for repo):
```
['.dvcignore', 'LICENSE', 'LITERATURE_REVIEW.md', 'logs', 'dagshub-savta-depth', 'run_dev_env.sh', 'dvc.lock', '.gitignore', 'Notebooks', '.dagshub-streaming', 'src', 'Makefile', 'README.md', 'requirements.txt', '.dvc', 'dvc.yaml']
['.dvcignore', 'LICENSE', 'streamlit', 'dvc.lock', 'data_processing', '.gitignore', 'prod_model', '.dagshub-streaming', 'data_labeling', 'evaluating', 'src', 'README.md', 'modeling', 'requirements.txt', '.dvc', 'streamlit_app.py', 'dvc.yaml']
```

Actual return before this PR (always lists result for the first repo queried):
```
['dagshub-savta-depth', 'logs', 'Notebooks', 'LITERATURE_REVIEW.md', 'dvc.yaml', '.dagshub-streaming', 'LICENSE', 'README.md', 'Makefile', '.gitignore', 'requirements.txt', 'run_dev_env.sh', '.dvcignore', '.dvc', 'dvc.lock', 'src']
['dagshub-savta-depth', 'logs', 'Notebooks', 'LITERATURE_REVIEW.md', 'dvc.yaml', '.dagshub-streaming', 'LICENSE', 'README.md', 'Makefile', '.gitignore', 'requirements.txt', 'run_dev_env.sh', '.dvcignore', '.dvc', 'dvc.lock', 'src']
```