### PR TITLE
Add ability to access integrated storage buckets via streaming

### DIFF
--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -136,7 +136,8 @@ def upload(ctx,
            host,
            **kwargs):
     """
-    Upload FILENAME to REPO at location TARGET [Unlike git push, we upload your data to DagsHub once and don't sync the repo state]
+    Upload FILENAME to REPO at location TARGET
+    [Unlike git push, we upload your data to DagsHub once and don't sync the repo state]
     REPO should be of the form <owner>/<repo-name>, i.e nirbarazida/yolov6.
     TARGET should include the full path inside the repo, including the filename itself.
     """
@@ -162,7 +163,7 @@ def repo():
 @repo.command()
 @click.argument("repo_name")
 @click.option("-u", "--upload-data", help="Upload data from specified url to new repository")
-@click.option("-c", "--clone", is_flag=True,  help="Clone repository locally")
+@click.option("-c", "--clone", is_flag=True, help="Clone repository locally")
 @click.option("-v", "--verbose", default=0, count=True, help="Verbosity level")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress print output")
 @click.pass_context

--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -136,7 +136,7 @@ def upload(ctx,
            host,
            **kwargs):
     """
-    Upload FILENAME to REPO at location TARGET.
+    Upload FILENAME to REPO at location TARGET [Unlike git push, we upload your data to DagsHub once and don't sync the repo state]
     REPO should be of the form <owner>/<repo-name>, i.e nirbarazida/yolov6.
     TARGET should include the full path inside the repo, including the filename itself.
     """

--- a/dagshub/common/helpers.py
+++ b/dagshub/common/helpers.py
@@ -42,8 +42,8 @@ def http_request(method, url, **kwargs):
 def get_project_root(root):
     while not (root / '.git').is_dir():
         if ismount(root):
-            raise ValueError('No git project found! (stopped at mountpoint {root}). \
-                             Please run this command in a git repository.')
+            raise ValueError(f"No git project found! (stopped at mountpoint {root}). \
+                               Please run this command in a git repository.")
         root = root / '..'
     return Path(root)
 

--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -19,8 +19,8 @@ def init(repo_name=None, repo_owner=None, url=None, root=None,
     if dvc:
         root = root or get_project_root(Path(os.path.abspath('.')))
         if not exists(root / '.git'):
-            raise ValueError('No git project found! (stopped at mountpoint {root}). \
-                              Please run this command in a git repository.')
+            raise ValueError(f'No git project found! (stopped at mountpoint {root}). \
+                               Please run this command in a git repository.')
 
     if url and (repo_name or repo_owner):
         repo_name, repo_owner = None, None

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import auto, Flag
 from pathlib import Path
 from typing import Optional, Any
 
@@ -37,15 +36,7 @@ class ContentAPIEntry:
     content_url: Optional[str]  # TODO: remove Optional once content_url is exposed in API
 
 
-class DagshubPathType(Flag):
-    UNKNOWN = auto()
-    TRACKED_IN_REPO = auto()
-    OUT_OF_REPO = auto()
-    STORAGE_PATH = auto()
-    PASSTHROUGH_PATH = auto()
-
-
-storage_schemas = ["s3:/", "gs:/"]
+storage_schemas = ["s3", "gs"]
 
 
 @dataclass
@@ -69,24 +60,10 @@ class DagshubPath:
         if self.relative_path is not None:
             str_path = self.relative_path.as_posix()
             for storage_schema in storage_schemas:
-                if str_path.startswith(storage_schema):
-                    str_path = str_path[len(f"{storage_schema}"):]
-                    self.relative_path = Path(".dagshub/storage") / storage_schema[:-2] / str_path
+                if str_path.startswith(f"{storage_schema}:/"):
+                    str_path = str_path[len(storage_schema) + 2:]
+                    self.relative_path = Path(".dagshub/storage") / storage_schema / str_path
                     self.absolute_path = self.fs.project_root / self.relative_path
-
-    @cached_property
-    def path_type(self):
-        if self.absolute_path is None:
-            return DagshubPathType.UNKNOWN
-        if self.relative_path is None:
-            return DagshubPathType.OUT_OF_REPO
-
-        res = DagshubPathType.TRACKED_IN_REPO
-        if self._is_storage_path():
-            res |= DagshubPathType.STORAGE_PATH
-        if self._is_passthrough_path():
-            res |= DagshubPathType.PASSTHROUGH_PATH
-        return res
 
     @cached_property
     def name(self):
@@ -94,32 +71,26 @@ class DagshubPath:
 
     @cached_property
     def is_in_repo(self):
-        return not (DagshubPathType.OUT_OF_REPO in self.path_type or DagshubPathType.UNKNOWN in self.path_type)
+        return self.absolute_path is not None and self.relative_path is not None
 
-    @property
-    def content_url(self):
-        if not self.is_in_repo:
-            raise RuntimeError(f"Can't access path {self.absolute_path} outside of repo")
-        str_path = self.relative_path.as_posix()
-        if DagshubPathType.STORAGE_PATH in self.path_type:
-            path_to_access = str_path[len(".dagshub/storage/"):]
-            return f"{self.fs.storage_content_api_url}/{path_to_access}"
-        return f"{self.fs.content_api_url}/{str_path}"
-
-    @property
-    def raw_url(self):
-        if not self.is_in_repo:
-            raise RuntimeError(f"Can't access path {self.absolute_path} outside of repo")
-        str_path = self.relative_path.as_posix()
-        if DagshubPathType.STORAGE_PATH in self.path_type:
-            path_to_access = str_path[len(".dagshub/storage/"):]
-            return f"{self.fs.storage_raw_api_url}/{path_to_access}"
-        return f"{self.fs.raw_api_url}/{str_path}"
-
-    def _is_storage_path(self):
+    @cached_property
+    def is_storage_path(self):
+        """
+        Is path a storage path (stored in a bucket)
+        Those paths are accessible via a path like `.dagshub/storage/s3/bucket/...`
+        """
         return self.relative_path.as_posix().startswith(".dagshub/storage")
 
-    def _is_passthrough_path(self):
+    @cached_property
+    def is_passthrough_path(self):
+        """
+        Is path a "passthrough" path
+        A passthrough path is a path that the FS ignores when trying to look up if the file exists on DagsHub
+        This includes:
+            - .git and .dvc folders - that prevents accidental access to their caches.
+                If you need to read with streaming from a .dvc folder (to read config for example), please pull the repo
+            - Any /site-packages/ folder - if you have a venv in your repo, python will try to find packages there.
+        """
         str_path = self.relative_path.as_posix()
         if "/site-packages/" in str_path:
             return True

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -23,6 +23,10 @@ class StorageAPIEntry:
     def full_path(self):
         return f"{self.protocol}/{self.name}"
 
+    @property
+    def path_in_mount(self) -> Path:
+        return Path(".dagshub/storage") / self.protocol / self.name
+
 @dataclass
 class ContentAPIEntry:
     path: str

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Storage:
+    name: str
+    protocol: str
+    list_path: str

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -1,8 +1,20 @@
 from dataclasses import dataclass
+from enum import auto, Flag
+from pathlib import Path
+from typing import Optional
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 
 @dataclass
-class StorageAPIResult:
+class StorageAPIEntry:
     name: str
     protocol: str
     list_path: str
@@ -12,10 +24,67 @@ class StorageAPIResult:
         return f"{self.protocol}/{self.name}"
 
 @dataclass
-class ContentAPIResult:
+class ContentAPIEntry:
     path: str
+    # Possible values: dir, file, storage
     type: str
     size: int
     hash: str
+    # Possible values: git, dvc, bucket
     versioning: str
     download_url: str
+    content_url: str
+
+
+class DagshubPathType(Flag):
+    UNKNOWN = auto()
+    TRACKED_IN_REPO = auto()
+    OUT_OF_REPO = auto()
+    STORAGE_PATH = auto()
+    PASSTHROUGH_PATH = auto()
+
+
+@dataclass
+class DagshubPath:
+    """
+    Class for handling any path used inside the virtual filesystem
+
+    Attributes:
+        absolute_path (Path): Absolute path in the system
+        relative_path (Optional[Path]): Path relative to the root of the encapsulating FileSystem.
+                                        If None, path is outside the FS
+    """
+    absolute_path: Optional[Path]
+    relative_path: Optional[Path]
+
+    @cached_property
+    def path_type(self):
+        if self.absolute_path is None:
+            return DagshubPathType.UNKNOWN
+        if self.relative_path is None:
+            return DagshubPathType.OUT_OF_REPO
+
+        res = DagshubPathType.TRACKED_IN_REPO
+        if self._is_storage_path():
+            res |= DagshubPathType.STORAGE_PATH
+        if self._is_passthrough_path():
+            res |= DagshubPathType.PASSTHROUGH_PATH
+        return res
+
+    @property
+    def name(self):
+        return self.absolute_path.name
+
+    @property
+    def is_in_repo(self):
+        return not (DagshubPathType.OUT_OF_REPO in self.path_type or DagshubPathType.UNKNOWN in self.path_type)
+
+    def _is_storage_path(self):
+        return self.relative_path.as_posix().startswith(".dagshub/storage")
+
+    def _is_passthrough_path(self):
+        str_path = self.relative_path.as_posix()
+        if "/site-packages/" in str_path:
+            return True
+        return str_path.startswith(('.git/', '.dvc/')) or str_path in (".git", ".dvc")
+

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -2,7 +2,20 @@ from dataclasses import dataclass
 
 
 @dataclass
-class Storage:
+class StorageAPIResult:
     name: str
     protocol: str
     list_path: str
+
+    @property
+    def full_path(self):
+        return f"{self.protocol}/{self.name}"
+
+@dataclass
+class ContentAPIResult:
+    path: str
+    type: str
+    size: int
+    hash: str
+    versioning: str
+    download_url: str

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     from cached_property import cached_property
 
+
 @dataclass
 class StorageAPIEntry:
     name: str
@@ -26,6 +27,7 @@ class StorageAPIEntry:
     @cached_property
     def path_in_mount(self) -> Path:
         return Path(".dagshub/storage") / self.protocol / self.name
+
 
 @dataclass
 class ContentAPIEntry:
@@ -50,6 +52,7 @@ class DagshubPathType(Flag):
 
 storage_schemas = ["s3:/", "gs:/"]
 
+
 @dataclass
 class DagshubPath:
     """
@@ -62,7 +65,7 @@ class DagshubPath:
                                         If None, path is outside the FS
     """
     # TODO: this couples this class hard to the fs, need to decouple later
-    fs: Any # Actual type is DagsHubFilesystem, but imports are wonky
+    fs: Any  # Actual type is DagsHubFilesystem, but imports are wonky
     absolute_path: Optional[Path]
     relative_path: Optional[Path]
 
@@ -108,7 +111,6 @@ class DagshubPath:
             return f"{self.fs.storage_content_api_url}/{path_to_access}"
         return f"{self.fs.content_api_url}/{str_path}"
 
-
     @property
     def raw_url(self):
         if not self.is_in_repo:
@@ -119,8 +121,6 @@ class DagshubPath:
             return f"{self.fs.storage_raw_api_url}/{path_to_access}"
         return f"{self.fs.raw_api_url}/{str_path}"
 
-
-
     def _is_storage_path(self):
         return self.relative_path.as_posix().startswith(".dagshub/storage")
 
@@ -129,4 +129,3 @@ class DagshubPath:
         if "/site-packages/" in str_path:
             return True
         return str_path.startswith(('.git/', '.dvc/')) or str_path in (".git", ".dvc")
-

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -4,11 +4,6 @@ from pathlib import Path
 from typing import Optional, Any
 
 try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
-try:
     from functools import cached_property
 except ImportError:
     from cached_property import cached_property

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -33,7 +33,7 @@ class ContentAPIEntry:
     # Possible values: git, dvc, bucket
     versioning: str
     download_url: str
-    content_url: str
+    content_url: Optional[str]  # TODO: remove Optional once content_url is exposed in API
 
 
 class DagshubPathType(Flag):
@@ -71,11 +71,11 @@ class DagshubPath:
             res |= DagshubPathType.PASSTHROUGH_PATH
         return res
 
-    @property
+    @cached_property
     def name(self):
         return self.absolute_path.name
 
-    @property
+    @cached_property
     def is_in_repo(self):
         return not (DagshubPathType.OUT_OF_REPO in self.path_type or DagshubPathType.UNKNOWN in self.path_type)
 

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -129,8 +129,6 @@ class DagsHubFilesystem:
 
         self._listdir_cache: Dict[Tuple[str, bool], Optional[List[ContentAPIEntry]]] = {}
 
-        self._dotfolder = self.project_root / ".dagshub"
-
         # Check that the repo is accessible by accessing the content root
         response = self._api_listdir(DagshubPath(self, self.project_root, Path()))
         if response is None:

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -472,7 +472,7 @@ class DagsHubFilesystem:
         else:
             str_path = path
         parsed_path = self._parse_path(str_path)
-        if parsed_path.is_in_repo and not DagshubPathType.PASSTHROUGH_PATH in parsed_path.path_type:
+        if parsed_path.is_in_repo and DagshubPathType.PASSTHROUGH_PATH not in parsed_path.path_type:
             path = Path(str_path)
             local_filenames = set()
             try:
@@ -495,8 +495,8 @@ class DagsHubFilesystem:
             for entry in self.__scandir(path):
                 yield entry
 
-    def _get_special_paths(self, dh_path: DagshubPath, relative_to: PathLike, is_binary: bool) -> Set[
-        "dagshub_DirEntry"]:
+    def _get_special_paths(self, dh_path: DagshubPath, relative_to: PathLike, is_binary: bool) -> \
+        Set["dagshub_DirEntry"]:
         def generate_entry(path, is_directory):
             if isinstance(path, str):
                 path = Path(path)

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -17,7 +17,7 @@ import dacite
 from dagshub.common import config, helpers
 import logging
 from dagshub.common.helpers import http_request, get_project_root
-from dagshub.streaming.dataclasses import StorageAPIEntry, ContentAPIEntry, DagshubPath, DagshubPathType
+from dagshub.streaming.dataclasses import StorageAPIEntry, ContentAPIEntry, DagshubPath
 
 # Pre 3.11 - need to patch _NormalAccessor for _pathlib, because it pre-caches open and other functions.
 # In 3.11 _NormalAccessor was removed
@@ -127,7 +127,7 @@ class DagsHubFilesystem:
         self.token = token or config.token
         self.timeout = timeout or config.http_timeout
 
-        self._listdir_cache: Dict[Tuple[str, bool], Optional[List[ContentAPIEntry]]] = {}
+        self._listdir_cache: Dict[str, Optional[Tuple[List[ContentAPIEntry], bool]]] = {}
 
         # Check that the repo is accessible by accessing the content root
         response = self._api_listdir(DagshubPath(self, self.project_root, Path()))
@@ -275,7 +275,7 @@ class DagsHubFilesystem:
             if opener is not None:
                 raise NotImplementedError('DagsHub\'s patched open() does not support custom openers')
             project_root_opener = partial(os.open, dir_fd=self.project_root_fd)
-            if DagshubPathType.PASSTHROUGH_PATH in path.path_type:
+            if path.is_passthrough_path:
                 return self.__open(path.relative_path, mode, buffering, encoding, errors, newline,
                                    closefd, opener=project_root_opener)
             elif path.relative_path == SPECIAL_FILE:
@@ -359,7 +359,7 @@ class DagsHubFilesystem:
         # todo: remove False
         if parsed_path.is_in_repo:
             logger.debug("fs.stat - is relative path")
-            if DagshubPathType.PASSTHROUGH_PATH in parsed_path.path_type:
+            if parsed_path.is_passthrough_path:
                 return self.__stat(parsed_path.relative_path, dir_fd=self.project_root_fd)
             elif parsed_path.relative_path == SPECIAL_FILE:
                 return dagshub_stat_result(self, path, is_directory=False, custom_size=len(self._special_file()))
@@ -426,7 +426,7 @@ class DagsHubFilesystem:
             str_path = path
         parsed_path = self._parse_path(str_path)
         if parsed_path.is_in_repo:
-            if DagshubPathType.PASSTHROUGH_PATH in parsed_path.path_type:
+            if parsed_path.is_passthrough_path:
                 with self._open_fd(parsed_path.relative_path) as fd:
                     return self.__listdir(fd)
             else:
@@ -470,7 +470,7 @@ class DagsHubFilesystem:
         else:
             str_path = path
         parsed_path = self._parse_path(str_path)
-        if parsed_path.is_in_repo and DagshubPathType.PASSTHROUGH_PATH not in parsed_path.path_type:
+        if parsed_path.is_in_repo and not parsed_path.is_passthrough_path:
             path = Path(str_path)
             local_filenames = set()
             try:
@@ -524,7 +524,7 @@ class DagsHubFilesystem:
         response, hit = self._check_listdir_cache(path.relative_path.as_posix(), include_size)
         if hit:
             return response
-        response = self.http_get(path.content_url,
+        response = self.http_get(self._content_url_for_path(path),
                                  params={'include_size': 'true'} if include_size else {},
                                  headers=config.requests_headers)
         if response.status_code >= 400:
@@ -537,7 +537,7 @@ class DagsHubFilesystem:
             if entry.type == "storage":
                 continue
             res.append(entry)
-        self._listdir_cache[(path.relative_path.as_posix(), include_size)] = res
+        self._listdir_cache[path.relative_path.as_posix()] = (res, include_size)
         return res
 
     def _api_storages(self) -> List[StorageAPIEntry]:
@@ -546,18 +546,37 @@ class DagsHubFilesystem:
             logger.warning(f"Got HTTP code {response.status_code} while getting storages. Content: {response.content}")
             logger.warning("Storages are unavailable")
             return []
-        return [dacite.from_dict(StorageAPIEntry, a) for a in response.json()]
+        return [dacite.from_dict(StorageAPIEntry, storage_entry) for storage_entry in response.json()]
 
     def _check_listdir_cache(self, path: str, include_size: bool) -> Tuple[Optional[List[ContentAPIEntry]], bool]:
-        # If we already have a response with side included, return that
-        if (path, True) in self._listdir_cache and not include_size:
-            self._listdir_cache[(path, False)] = self._listdir_cache[(path, True)]
-        if (path, include_size) in self._listdir_cache:
-            return self._listdir_cache[(path, include_size)], True
+        # Checks that path has a pre-cached response
+        # If include_size is True, but only a response without size is cached, that's a cache miss
+        if path in self._listdir_cache:
+            cache_val, with_size = self._listdir_cache[path]
+            if not include_size or (include_size and with_size):
+                return cache_val, True
         return None, False
 
+    def _content_url_for_path(self, path: DagshubPath):
+        if not path.is_in_repo:
+            raise RuntimeError(f"Can't access path {path.absolute_path} outside of repo")
+        str_path = path.relative_path.as_posix()
+        if path.is_storage_path:
+            path_to_access = str_path[len(".dagshub/storage/"):]
+            return f"{self.storage_content_api_url}/{path_to_access}"
+        return f"{self.content_api_url}/{str_path}"
+
+    def _raw_url_for_path(self, path: DagshubPath):
+        if not path.is_in_repo:
+            raise RuntimeError(f"Can't access path {path.absolute_path} outside of repo")
+        str_path = path.relative_path.as_posix()
+        if path.is_storage_path:
+            path_to_access = str_path[len(".dagshub/storage/"):]
+            return f"{self.storage_raw_api_url}/{path_to_access}"
+        return f"{self.raw_api_url}/{str_path}"
+
     def _api_download_file_git(self, path: DagshubPath):
-        return self.http_get(path.raw_url, headers=config.requests_headers, timeout=None)
+        return self.http_get(self._raw_url_for_path(path), headers=config.requests_headers, timeout=None)
 
     def http_get(self, path: str, **kwargs):
         timeout = self.timeout

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -148,7 +148,6 @@ class DagsHubFilesystem:
             raise AuthenticationError('DagsHub credentials required, however none provided or discovered')
 
         self._storages = self._api_storages()
-        print(self._storages)
 
     @property
     @lru_cache(maxsize=None)
@@ -269,10 +268,10 @@ class DagsHubFilesystem:
             return DagshubPath(None, None)
         abspath = Path(os.path.abspath(file))
         try:
-            rel = abspath.relative_to(os.path.abspath(self.project_root))
-            if str(rel).startswith("<"):
+            relpath = abspath.relative_to(os.path.abspath(self.project_root))
+            if str(relpath).startswith("<"):
                 return DagshubPath(abspath, None)
-            return DagshubPath(abspath, rel)
+            return DagshubPath(abspath, relpath)
         except ValueError:
             return DagshubPath(abspath, None)
 

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -495,8 +495,9 @@ class DagsHubFilesystem:
             for entry in self.__scandir(path):
                 yield entry
 
-    def _get_special_paths(self, dh_path: DagshubPath, relative_to: PathLike, is_binary: bool) -> \
-        Set["dagshub_DirEntry"]:
+    def _get_special_paths(
+        self, dh_path: DagshubPath, relative_to: PathLike, is_binary: bool
+    ) -> Set["dagshub_DirEntry"]:
         def generate_entry(path, is_directory):
             if isinstance(path, str):
                 path = Path(path)

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -390,7 +390,6 @@ class DataSet:
         self.files: Dict[os.PathLike, Tuple[os.PathLike, BinaryIO]] = {}
         self.repo = repo
         self.directory = self._clean_directory_name(directory)
-        self.request_url = self.repo.get_request_url(directory)
 
     def add(self, file: Union[str, IOBase], path=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import setuptools
 import os.path
 
@@ -23,6 +24,23 @@ def get_version(rel_path: str) -> str:
 with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
+install_requires=[
+    "PyYAML>=5",
+    "fusepy>=3",
+    "appdirs>=1.4.4",
+    "click>=8.0.4",
+    "httpx==0.22.0",
+    "GitPython>=3.1.29",
+    "rich[jupyter]~=13.1.0",
+    "dacite~=1.8.0",
+]
+
+# Polyfills for Python 3.7
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    install_requires += [
+        "typing-extensions~=4.5.0",
+        "cached-property==1.5.2"
+    ]
 
 setuptools.setup(
     name="dagshub",
@@ -34,15 +52,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/DagsHub/client",
     packages=setuptools.find_packages(),
-    install_requires=[
-        "PyYAML>=5",
-        "fusepy>=3",
-        "appdirs>=1.4.4",
-        "click>=8.0.4",
-        "httpx==0.22.0",
-        "GitPython>=3.1.29",
-        "rich[jupyter]~=13.1.0",
-    ],
+    install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version(rel_path: str) -> str:
 with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
-install_requires=[
+install_requires = [
     "PyYAML>=5",
     "fusepy>=3",
     "appdirs>=1.4.4",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ install_requires = [
 # Polyfills for Python 3.7
 if sys.version_info.major == 3 and sys.version_info.minor == 7:
     install_requires += [
-        "typing-extensions~=4.5.0",
         "cached-property==1.5.2"
     ]
 

--- a/tests/dda/filesystem/conftest.py
+++ b/tests/dda/filesystem/conftest.py
@@ -1,9 +1,9 @@
 import pytest
-import dagshub
+from dagshub.streaming import install_hooks, uninstall_hooks
 
 
 @pytest.fixture
 def repo_with_hooks(dagshub_repo):
-    dagshub.streaming.install_hooks()
+    install_hooks()
     yield dagshub_repo
-    dagshub.streaming.uninstall_hooks()
+    uninstall_hooks()

--- a/tests/dda/filesystem/test_listdir.py
+++ b/tests/dda/filesystem/test_listdir.py
@@ -30,6 +30,30 @@ def test_listdir_includes_local_files(mock_api, repo_with_hooks):
         actual = os.listdir(".")
         assert set(expected) == set(actual)
 
+def test_has_storage_bucket_paths(mock_api, repo_with_hooks):
+    bucket_path = mock_api.storage_bucket_path
+    bucket_path_elems = bucket_path.split("/")
+    assert len(bucket_path_elems) == 2
+    for root, dirs, files in os.walk("."):
+        if root == ".":
+            assert ".dagshub" in dirs
+        elif root == "./.dagshub":
+            assert "storage" in dirs
+        elif root == "./.dagshub/storage":
+            assert "s3" in dirs
+        elif root == "./.dagshub/storage/s3":
+            assert bucket_path_elems[0] in dirs
+        elif root == f"./.dagshub/storage/s3/{bucket_path_elems[0]}":
+            assert bucket_path_elems[1] in dirs
+
+
+def test_lists_bucket_folder(mock_api, repo_with_hooks):
+    files = [("a.txt", "file"), ("b.txt", "file"), ("dir1", "dir")]
+    path = "testdir"
+    mock_api.add_dir(path, files, is_storage=True)
+    actual = os.listdir(f".dagshub/storage/s3/{mock_api.storage_bucket_path}/{path}")
+    expected = [f[0] for f in files]
+    assert set(actual) == set(expected)
 
 def test_binary(mock_api, repo_with_hooks):
     files = [("a.txt", "file"), ("b.txt", "file"), ("dir1", "dir")]

--- a/tests/dda/filesystem/test_listdir.py
+++ b/tests/dda/filesystem/test_listdir.py
@@ -30,6 +30,7 @@ def test_listdir_includes_local_files(mock_api, repo_with_hooks):
         actual = os.listdir(".")
         assert set(expected) == set(actual)
 
+
 def test_has_storage_bucket_paths(mock_api, repo_with_hooks):
     bucket_path = mock_api.storage_bucket_path
     bucket_path_elems = bucket_path.split("/")
@@ -54,6 +55,7 @@ def test_lists_bucket_folder(mock_api, repo_with_hooks):
     actual = os.listdir(f".dagshub/storage/s3/{mock_api.storage_bucket_path}/{path}")
     expected = [f[0] for f in files]
     assert set(actual) == set(expected)
+
 
 def test_binary(mock_api, repo_with_hooks):
     files = [("a.txt", "file"), ("b.txt", "file"), ("dir1", "dir")]

--- a/tests/dda/filesystem/test_misc.py
+++ b/tests/dda/filesystem/test_misc.py
@@ -1,4 +1,5 @@
 import os.path
+from unittest.mock import MagicMock
 
 import pytest
 from pathlib import Path
@@ -20,6 +21,7 @@ from dagshub.streaming.dataclasses import DagshubPath, DagshubPathType
     ],
 )
 def test_passthrough_path(path, expected):
-    path = DagshubPath(Path(os.path.abspath(path)), Path(path))
+    fs_mock = MagicMock()
+    path = DagshubPath(fs_mock, Path(os.path.abspath(path)), Path(path))
     actual = DagshubPathType.PASSTHROUGH_PATH in path.path_type
     assert actual == expected

--- a/tests/dda/filesystem/test_misc.py
+++ b/tests/dda/filesystem/test_misc.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from pathlib import Path
-from dagshub.streaming.dataclasses import DagshubPath, DagshubPathType
+from dagshub.streaming.dataclasses import DagshubPath
 
 
 @pytest.mark.parametrize(
@@ -23,5 +23,5 @@ from dagshub.streaming.dataclasses import DagshubPath, DagshubPathType
 def test_passthrough_path(path, expected):
     fs_mock = MagicMock()
     path = DagshubPath(fs_mock, Path(os.path.abspath(path)), Path(path))
-    actual = DagshubPathType.PASSTHROUGH_PATH in path.path_type
+    actual = path.is_passthrough_path
     assert actual == expected

--- a/tests/dda/filesystem/test_misc.py
+++ b/tests/dda/filesystem/test_misc.py
@@ -1,6 +1,8 @@
+import os.path
+
 import pytest
 from pathlib import Path
-from dagshub.streaming import DagsHubFilesystem
+from dagshub.streaming.dataclasses import DagshubPath, DagshubPathType
 
 
 @pytest.mark.parametrize(
@@ -18,6 +20,6 @@ from dagshub.streaming import DagsHubFilesystem
     ],
 )
 def test_passthrough_path(path, expected):
-    path = Path(path)
-    actual = DagsHubFilesystem._passthrough_path(path)
+    path = DagshubPath(Path(os.path.abspath(path)), Path(path))
+    actual = DagshubPathType.PASSTHROUGH_PATH in path.path_type
     assert actual == expected

--- a/tests/dda/filesystem/test_open.py
+++ b/tests/dda/filesystem/test_open.py
@@ -24,8 +24,16 @@ def test_open_nested_path(mock_api, repo_with_hooks):
     mock_api.add_file(path, content)
     with open(path, "rb") as f:
         assert f.read() == content
-    print(os.path.dirname(path))
     assert os.path.exists(os.path.dirname(path))
+
+def test_open_nested_storage(mock_api, repo_with_hooks):
+    path = "nested/path/a.txt"
+    content = b"Hello, streaming world!"
+    mock_api.add_file(path, content, is_storage=True)
+    actual_path = f".dagshub/storage/s3/{mock_api.storage_bucket_path}/{path}"
+    with open(actual_path, "rb") as f:
+        assert f.read() == content
+    assert os.path.exists(os.path.dirname(actual_path))
 
 
 def test_open_for_write(mock_api, repo_with_hooks):

--- a/tests/dda/filesystem/test_open.py
+++ b/tests/dda/filesystem/test_open.py
@@ -26,6 +26,7 @@ def test_open_nested_path(mock_api, repo_with_hooks):
         assert f.read() == content
     assert os.path.exists(os.path.dirname(path))
 
+
 def test_open_nested_storage(mock_api, repo_with_hooks):
     path = "nested/path/a.txt"
     content = b"Hello, streaming world!"

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -3,8 +3,6 @@ import os.path
 from httpx import Response
 from respx import MockRouter, Route
 
-BASE_REGEX = r"/api/v1/repos/\w+/\w+"
-
 
 class MockApi(MockRouter):
     def __init__(self, git_repo, user="user", reponame="repo", *args, **kwargs):
@@ -26,6 +24,10 @@ class MockApi(MockRouter):
         return f"{self.user}/{self.reponame}"
 
     @property
+    def repoapipath(self):
+        return f"/api/v1/repos/{self.repourlpath}"
+
+    @property
     def repophysicalpath(self):
         return str(self.git_repo.workspace)
 
@@ -39,18 +41,19 @@ class MockApi(MockRouter):
 
     @property
     def api_list_path(self):
-        return f"/api/v1/repos/{self.repourlpath}/content/{self.current_revision}"
+        return f"{self.repoapipath}/content/{self.current_revision}"
 
     @property
     def api_raw_path(self):
-        return f"/api/v1/repos/{self.repourlpath}/raw/{self.current_revision}"
+        return f"{self.repoapipath}/raw/{self.current_revision}"
 
     def _default_endpoints_and_responses(self):
         endpoints = {
-            "repo": rf"/api/v1/repos/{self.repourlpath}/?$",
-            "branch": rf"{BASE_REGEX}/branches/\w+",
-            "branches": rf"{BASE_REGEX}/branches",
-            "list_root": rf"{BASE_REGEX}/content/{self.current_revision}/$",
+            "repo": rf"{self.repoapipath}/?$",
+            "branch": rf"{self.repoapipath}/branches/\w+",
+            "branches": rf"{self.repoapipath}/branches",
+            "list_root": rf"{self.repoapipath}/content/{self.current_revision}/$",
+            "storages": rf"{self.repoapipath}/storage/?$"
         }
 
         responses = {
@@ -68,7 +71,7 @@ class MockApi(MockRouter):
                     "name": self.reponame,
                     "full_name": self.repourlpath,
                     "description": "Open Source Data Science (OSDS) Monocular Depth Estimation "
-                    "– Turn 2d photos into 3d photos – show your grandma the awesome results.",
+                                   "– Turn 2d photos into 3d photos – show your grandma the awesome results.",
                     "private": False,
                     "fork": False,
                     "parent": None,
@@ -177,6 +180,16 @@ class MockApi(MockRouter):
                     },
                 ],
             ),
+            "storages": Response(
+                200,
+                json=[
+                    {
+                        "name": "storage-bucket/prefix",
+                        "protocol": "s3",
+                        "list_path": f"{self.repoapipath}/storage/content/s3/storage-bucket/prefix"
+                    }
+                ]
+            )
         }
 
         return endpoints, responses

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -153,6 +153,7 @@ class MockApi(MockRouter):
                         "hash": "some_hash",
                         "versioning": "dvc",
                         "download_url": "some_url",
+                        "content_url": "some_url",
                     },
                     {
                         "path": "b.txt",
@@ -161,6 +162,7 @@ class MockApi(MockRouter):
                         "hash": "some_hash",
                         "versioning": "dvc",
                         "download_url": "some_url",
+                        "content_url": "some_url",
                     },
                     {
                         "path": "c.txt",
@@ -169,6 +171,7 @@ class MockApi(MockRouter):
                         "hash": "some_hash",
                         "versioning": "dvc",
                         "download_url": "some_url",
+                        "content_url": "some_url",
                     },
                     {
                         "path": "a.txt.dvc",
@@ -177,6 +180,7 @@ class MockApi(MockRouter):
                         "hash": "some_hash",
                         "versioning": "git",
                         "download_url": "some_url",
+                        "content_url": "some_url",
                     },
                 ],
             ),
@@ -229,4 +233,5 @@ class MockApi(MockRouter):
             "hash": "8586da76f372efa83d832a9d0e664817.dir",
             "versioning": "dvc",
             "download_url": f"https://dagshub.com/{self.repourlpath}/raw/{self.current_revision}/{path}",
+            "content_url": f"https://dagshub.com/{self.repourlpath}/content/{self.current_revision}/{path}",
         }


### PR DESCRIPTION
The buckets are accessible via `.dagshub/storage/{protocol}/{bucket}` path in the root of the repository.

Also added some refactorings for how paths are handled, was required to handle storage paths differently from the regular ones.

Added tests:
- The directories are displayed in `os.listdir` and `os.walk`
- If the storage bucket has a directory with files, those files are displayed
- If the user tries to open a file in the storage directory, it is downloaded

I've also tested exploratorily that it worked with a toy repository.
Haven't tested that with a proper ML-project repo, considering passing tests to be a sign that it shouldn't break, but let me know if it does break