### PR TITLE
1634 Prevent users from mounting multiple filesystems in the same location

### DIFF
--- a/dagshub/streaming/errors.py
+++ b/dagshub/streaming/errors.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 
 class FilesystemAlreadyMountedError(Exception):
-    def __init__(self, path: Path, revision: str):
+    def __init__(self, path: Path, repo: str, revision: str):
         self.path = path
+        self.repo = repo
         self.revision = revision
 
     def __str__(self):
-        return f"Filesystem bound to revision \"{self.revision}\" is already mounted at path {self.path.absolute()}"
+        return f"There is already a filesystem mounted at path {self.path.absolute()} ({self.repo} revision {self.revision})" \
+               f"\ndel() the filesystem object in use if you want to switch the mounted filesystem"

--- a/dagshub/streaming/errors.py
+++ b/dagshub/streaming/errors.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+class FilesystemAlreadyMountedError(Exception):
+    def __init__(self, path: Path, revision: str):
+        self.path = path
+        self.revision = revision
+
+    def __str__(self):
+        return f"Filesystem bound to revision \"{self.revision}\" is already mounted at path {self.path.absolute()}"

--- a/dagshub/streaming/errors.py
+++ b/dagshub/streaming/errors.py
@@ -8,5 +8,6 @@ class FilesystemAlreadyMountedError(Exception):
         self.revision = revision
 
     def __str__(self):
-        return f"There is already a filesystem mounted at path {self.path.absolute()} ({self.repo} revision {self.revision})" \
+        return f"There is already a filesystem mounted at path {self.path.absolute()} " \
+               f"({self.repo} revision {self.revision})" \
                f"\ndel() the filesystem object in use if you want to switch the mounted filesystem"

--- a/tests/dda/filesystem/test_misc.py
+++ b/tests/dda/filesystem/test_misc.py
@@ -1,9 +1,14 @@
 import os.path
+import secrets
+import tempfile
 from unittest.mock import MagicMock
 
 import pytest
 from pathlib import Path
+
+from dagshub.streaming import DagsHubFilesystem
 from dagshub.streaming.dataclasses import DagshubPath, DagshubPathType
+from dagshub.streaming.errors import FilesystemAlreadyMountedError
 
 
 @pytest.mark.parametrize(
@@ -25,3 +30,26 @@ def test_passthrough_path(path, expected):
     path = DagshubPath(fs_mock, Path(os.path.abspath(path)), Path(path))
     actual = DagshubPathType.PASSTHROUGH_PATH in path.path_type
     assert actual == expected
+
+
+def test_cant_mount_multiples_in_same_dir(mock_api):
+    new_branch = "new"
+    sha = secrets.token_hex(nbytes=20)
+    mock_api.add_branch(new_branch, sha)
+    fs = DagsHubFilesystem(project_root=".", repo_url="https://dagshub.com/user/repo")
+    with pytest.raises(FilesystemAlreadyMountedError):
+        fs_new = DagsHubFilesystem(project_root=".", repo_url="https://dagshub.com/user/repo", branch=new_branch)
+
+def test_can_mount_multiple_in_different_dirs(mock_api):
+    new_branch = "new"
+    sha = secrets.token_hex(nbytes=20)
+    mock_api.add_branch(new_branch, sha)
+
+    fs = DagsHubFilesystem(project_root=".", repo_url="https://dagshub.com/user/repo")
+
+    other_path = tempfile.mkdtemp()
+    resp = mock_api._default_endpoints_and_responses()[1]["list_root"]
+    mock_api.get(url=f"/api/v1/repos/user/repo/content/{sha}/").mock(resp)
+
+    fs_new = DagsHubFilesystem(project_root=other_path, repo_url="https://dagshub.com/user/repo", branch=new_branch)
+

--- a/tests/dda/filesystem/test_misc.py
+++ b/tests/dda/filesystem/test_misc.py
@@ -41,11 +41,11 @@ def test_cant_mount_multiples(mock_api, a_path, b_path, create_folder):
     new_branch = "new"
     sha = secrets.token_hex(nbytes=20)
     mock_api.add_branch(new_branch, sha)
-    fs = DagsHubFilesystem(project_root=a_path, repo_url="https://dagshub.com/user/repo")
+    _ = DagsHubFilesystem(project_root=a_path, repo_url="https://dagshub.com/user/repo")
     if create_folder:
         os.makedirs(b_path, exist_ok=True)
     with pytest.raises(FilesystemAlreadyMountedError):
-        fs_new = DagsHubFilesystem(project_root=b_path, repo_url="https://dagshub.com/user/repo", branch=new_branch)
+        _ = DagsHubFilesystem(project_root=b_path, repo_url="https://dagshub.com/user/repo", branch=new_branch)
 
 
 def test_can_mount_multiple_in_different_dirs(mock_api):
@@ -53,10 +53,10 @@ def test_can_mount_multiple_in_different_dirs(mock_api):
     sha = secrets.token_hex(nbytes=20)
     mock_api.add_branch(new_branch, sha)
 
-    fs = DagsHubFilesystem(project_root=".", repo_url="https://dagshub.com/user/repo")
+    _ = DagsHubFilesystem(project_root=".", repo_url="https://dagshub.com/user/repo")
 
     other_path = tempfile.mkdtemp()
     resp = mock_api._default_endpoints_and_responses()[1]["list_root"]
     mock_api.get(url=f"/api/v1/repos/user/repo/content/{sha}/").mock(resp)
 
-    fs_new = DagsHubFilesystem(project_root=other_path, repo_url="https://dagshub.com/user/repo", branch=new_branch)
+    _ = DagsHubFilesystem(project_root=other_path, repo_url="https://dagshub.com/user/repo", branch=new_branch)

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -60,8 +60,8 @@ class MockApi(MockRouter):
     def _default_endpoints_and_responses(self):
         endpoints = {
             "repo": rf"{self.repoapipath}/?$",
-            "branch": rf"{self.repoapipath}/branches/\w+",
-            "branches": rf"{self.repoapipath}/branches",
+            "branch": rf"{self.repoapipath}/branches/(main|master)$",
+            "branches": rf"{self.repoapipath}/branches/?$",
             "list_root": rf"{self.repoapipath}/content/{self.current_revision}/$",
             "storages": rf"{self.repoapipath}/storage/?$"
         }
@@ -251,3 +251,30 @@ class MockApi(MockRouter):
             "download_url": f"https://dagshub.com/{self.repourlpath}/raw/{self.current_revision}/{path}",
             "content_url": f"https://dagshub.com/{self.repourlpath}/content/{self.current_revision}/{path}",
         }
+
+    def add_branch(self, branch, revision):
+        resp_json = {
+            "name": branch,
+            "commit": {
+                "id": revision,
+                "message": "Update 'README.md'\n",
+                "url": "",
+                "author": {
+                    "name": "dagshub",
+                    "email": "info@dagshub.com",
+                    "username": "",
+                },
+                "committer": {
+                    "name": "dagshub",
+                    "email": "info@dagshub.com",
+                    "username": "",
+                },
+                "added": None,
+                "removed": None,
+                "modified": None,
+                "timestamp": "2021-08-10T09:03:32Z",
+            }
+        }
+        branch_route = self.get(url=f"/api/v1/repos/{self.repourlpath}/branches/{branch}")
+        branch_route.mock(Response(200, json=resp_json))
+        return branch_route


### PR DESCRIPTION
# Spec
We want to prevent users from accidentally mounting multiple repositories into the same folder and then getting conflicting data.
On DagshubFilesystem creation I now check a static map of all "mounted" filesystems and if there is one mounted in either of:
- Same path
- Parent path of the path passed to the DagsHubFilesystem
- Child path of the path
I throw a `FilesystemAlreadyMountedError`

The map is cleared of a mounted filesystem on:
- Object cleanup (`__del__`)
- `unmount_hooks()`

# Testing
Added test cases that test most of this behavior (didn't test the object cleanup)

# Docs
Didn't add any :(