### PR TITLE
Handle continuation token in the Storage Content API

### DIFF
--- a/.github/workflows/run-linters.yaml
+++ b/.github/workflows/run-linters.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           flake8: true
-          flake8_args: "--max-line-length 120 --exclude oss_licenses.py"
+          flake8_args: "--max-line-length 120 --exclude oss_licenses.py --ignore=E203,W503"

--- a/.github/workflows/run-linters.yaml
+++ b/.github/workflows/run-linters.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           flake8: true
-          flake8_args: "--max-line-length 120 --exclude oss_licenses.py --ignore=E203,W503"
+          flake8_args: "--max-line-length 120 --exclude oss_licenses.py --ignore=E203,W503,W504,E125"

--- a/.github/workflows/run-linters.yaml
+++ b/.github/workflows/run-linters.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           flake8: true
-          flake8_args: "--max-line-length 120 --exclude oss_licenses.py --ignore=E203,W503,W504,E125"
+          flake8_args: "--max-line-length 120 --exclude oss_licenses.py --ignore=E203,W503,W504,E125,E126"

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -15,7 +15,7 @@ class HTTPBearerAuth(Auth):
     def __eq__(self, other):
         return all([
             self.token == getattr(other, 'token', None),
-            ])
+        ])
 
     def __ne__(self, other):
         return not self == other

--- a/dagshub/fastai/logger.py
+++ b/dagshub/fastai/logger.py
@@ -84,7 +84,7 @@ class DAGsHubLogger(Callback):
         self.run = True
         self._dags_epoch = round(self._dags_epoch)
         if self._dags_status_hyperparam_name is not None and \
-                self._dags_status_hyperparam_name not in self.logger.hparams:
+            self._dags_status_hyperparam_name not in self.logger.hparams:
             self.logger.log_hyperparams({self._dags_status_hyperparam_name: self.run})
         metrics = {n: s for n, s in zip(self.recorder.metric_names, self.recorder.log) if n not
                    in ['train_loss', 'epoch', 'time']}

--- a/dagshub/keras/logger.py
+++ b/dagshub/keras/logger.py
@@ -7,9 +7,11 @@ class ignore_exceptions:
     # Taken from fastcore code
     """Context manager to ignore exceptions"""
 
-    def __enter__(self): pass
+    def __enter__(self):
+        pass
 
-    def __exit__(self, *args): return True
+    def __exit__(self, *args):
+        return True
 
 
 class DAGsHubLogger(Callback):

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Any
+from typing import Optional, Any, List
 
 try:
     from functools import cached_property
@@ -34,6 +34,13 @@ class ContentAPIEntry:
     versioning: str
     download_url: str
     content_url: Optional[str]  # TODO: remove Optional once content_url is exposed in API
+
+
+@dataclass
+class StorageContentAPIResult:
+    entries: List[ContentAPIEntry]
+    next_token: str
+    limit: int
 
 
 storage_schemas = ["s3", "gs"]

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -39,8 +39,7 @@ class ContentAPIEntry:
 @dataclass
 class StorageContentAPIResult:
     entries: List[ContentAPIEntry]
-    next_token: str
-    limit: int
+    next_token: Optional[str]
 
 
 storage_schemas = ["s3", "gs"]

--- a/tests/dda/filesystem/test_listdir.py
+++ b/tests/dda/filesystem/test_listdir.py
@@ -71,7 +71,6 @@ def test_storage_pagination(mock_api, repo_with_hooks):
     assert set(actual) == set(expected)
 
 
-
 def test_binary(mock_api, repo_with_hooks):
     files = [("a.txt", "file"), ("b.txt", "file"), ("dir1", "dir")]
     path = "testdir"

--- a/tests/dda/filesystem/test_listdir.py
+++ b/tests/dda/filesystem/test_listdir.py
@@ -51,10 +51,25 @@ def test_has_storage_bucket_paths(mock_api, repo_with_hooks):
 def test_lists_bucket_folder(mock_api, repo_with_hooks):
     files = [("a.txt", "file"), ("b.txt", "file"), ("dir1", "dir")]
     path = "testdir"
-    mock_api.add_dir(path, files, is_storage=True)
+    mock_api.add_storage_dir(path, files)
     actual = os.listdir(f".dagshub/storage/s3/{mock_api.storage_bucket_path}/{path}")
     expected = [f[0] for f in files]
     assert set(actual) == set(expected)
+
+
+def test_storage_pagination(mock_api, repo_with_hooks):
+    files1 = [("a.txt", "file"), ("b.txt", "file"), ("dir1", "dir")]
+    files2 = [("c.txt", "file")]
+    path = "testdir"
+    # Order is important, otherwise respx loops and returns the first result indefinitely
+    mock_api.add_storage_dir(path, files2, from_token="aaa")
+    mock_api.add_storage_dir(path, files1, next_token="aaa")
+
+    expected = [f[0] for f in files1 + files2]
+
+    actual = os.listdir(f".dagshub/storage/s3/{mock_api.storage_bucket_path}/{path}")
+    assert set(actual) == set(expected)
+
 
 
 def test_binary(mock_api, repo_with_hooks):

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -224,13 +224,29 @@ class MockApi(MockRouter):
         Add a directory to the api (only accessible via the content endpoint)
         We don't keep a tree of added dirs, so it's not dynamic
         """
-        if is_storage:
-            route = self.route(url=f"{self.api_storage_list_path}/{path}")
-        else:
-            route = self.route(url=f"{self.api_list_path}/{path}")
+        route = self.route(url=f"{self.api_list_path}/{path}")
         content = [
             self.generate_list_entry(os.path.join(path, c[0]), c[1]) for c in contents
         ]
+        route.mock(Response(status, json=content))
+        return route
+
+    def add_storage_dir(self, path, contents=[], from_token=None, next_token=None, status=200):
+        """
+        Add a directory to the storage api
+        Storage has a different response schema
+        """
+        url = f"{self.api_storage_list_path}/{path}"
+        if from_token is not None:
+            url += f"?from_token={from_token}"
+        route = self.route(url=url)
+        content = {
+            "entries": [
+                self.generate_list_entry(os.path.join(path, c[0]), c[1]) for c in contents
+            ],
+            "limit": len(contents),
+            "next_token": next_token if next_token is not None else "",
+        }
         route.mock(Response(status, json=content))
         return route
 

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -236,17 +236,18 @@ class MockApi(MockRouter):
         Add a directory to the storage api
         Storage has a different response schema
         """
-        url = f"{self.api_storage_list_path}/{path}"
+        url = f"{self.api_storage_list_path}/{path}?paging=true"
         if from_token is not None:
-            url += f"?from_token={from_token}"
+            url += f"&from_token={from_token}"
         route = self.route(url=url)
         content = {
             "entries": [
                 self.generate_list_entry(os.path.join(path, c[0]), c[1]) for c in contents
             ],
             "limit": len(contents),
-            "next_token": next_token if next_token is not None else "",
         }
+        if next_token is not None:
+            content["next_token"] = next_token
         route.mock(Response(status, json=content))
         return route
 


### PR DESCRIPTION
**Only merge once the changes are deployed on the backend!**

# Spec
 
Content API for storages now returns struct with token pagination. This PR handles it.
Additionally, if there is a `next_token` field, we requery the backend to get all of the entries.

# Testing

Added test that handles the pagination case