### PR TITLE
Set guard checks in cleanup functions in case we delete mid-fs-creation

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -270,12 +270,13 @@ class DagsHubFilesystem:
             self.dagshub_remotes.append(remote.geturl())
 
     def __del__(self):
-        os.close(self.project_root_fd)
+        if hasattr(self, "project_root_fd"):
+            os.close(self.project_root_fd)
         self.cleanup()
 
     def cleanup(self):
         # Remove from map of mounted filesystems
-        if self.project_root in DagsHubFilesystem.already_mounted_filesystems:
+        if hasattr(self, "project_root") and self.project_root in DagsHubFilesystem.already_mounted_filesystems:
             DagsHubFilesystem.already_mounted_filesystems.pop(self.project_root)
 
     def _parse_path(self, file: Union[str, PathLike, int]) -> DagshubPath:


### PR DESCRIPTION
Raised by Yono - cleanup function sometimes throws errors on cleanup that `project_root_fd` is not defined on the fs. This should guard against this