### PR TITLE
Repo API consolidation

### DIFF
--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -1,5 +1,8 @@
 import logging
 
+from dagshub.common.api.responses import RepoAPIResponse, BranchAPIResponse, CommitAPIResponse, StorageAPIEntry, \
+    ContentAPIEntry, StorageContentAPIResult
+
 try:
     from functools import cached_property
 except ImportError:
@@ -14,7 +17,6 @@ from dagshub.auth.token_auth import HTTPBearerAuth
 from dagshub.common import config
 from urllib.parse import urljoin, quote
 
-from dagshub.common.api.responses import *
 from dagshub.common.helpers import http_request
 
 logger = logging.getLogger("dagshub")

--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -12,7 +12,7 @@ import dacite
 import dagshub.auth
 from dagshub.auth.token_auth import HTTPBearerAuth
 from dagshub.common import config
-from urllib.parse import urljoin, quote_plus
+from urllib.parse import urljoin, quote
 
 from dagshub.common.api.responses import RepoAPIResponse, BranchAPIResponse, CommitAPIResponse, StorageAPIEntry
 from dagshub.common.helpers import http_request
@@ -231,4 +231,4 @@ class RepoAPI:
 
 def _multi_urljoin(*parts):
     """Shoutout to https://stackoverflow.com/a/55722792"""
-    return urljoin(parts[0] + "/", "/".join(quote_plus(part.strip("/"), safe="/") for part in parts[1:]))
+    return urljoin(parts[0] + "/", "/".join(quote(part.strip("/"), safe="/") for part in parts[1:]))

--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -1,0 +1,120 @@
+import logging
+from functools import cached_property
+from typing import Optional, Tuple
+
+import dacite
+
+import dagshub.auth
+from dagshub.auth.token_auth import HTTPBearerAuth
+from dagshub.common import config
+import httpx
+from urllib.parse import urljoin, quote_plus
+
+from dagshub.common.api.responses import RepoAPIResponse, BranchAPIResponse
+
+logger = logging.getLogger("dagshub")
+
+
+class WrongRepoFormatError(Exception):
+    pass
+
+
+class RepoNotFoundError(Exception):
+    pass
+
+
+class BranchNotFoundError(Exception):
+    pass
+
+
+class RepoAPI:
+
+    def __init__(self, repo: str, host: Optional[str] = None):
+        self.owner, self.repo_name = self.parse_repo(repo)
+        self.host = host if host is not None else config.host
+
+        self.client = httpx.Client(
+            auth=HTTPBearerAuth(config.token or dagshub.auth.get_token(host=self.host))
+        )
+        print("Done")
+
+    def get_repo_info(self) -> RepoAPIResponse:
+        res = self.client.get(self.repo_api_url)
+
+        if res.status_code == 404:
+            raise RepoNotFoundError(f"Repo {self.repo_url} doesn't exist")
+        elif res.status_code >= 400:
+            error_msg = f"Got status code {res.status_code} when getting repository info."
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
+        return dacite.from_dict(RepoAPIResponse, res.json())
+
+    def get_branch_info(self, branch: str):
+        res = self.client.get(self.branch_url(branch))
+
+        if res.status_code == 404:
+            raise BranchNotFoundError(f"Branch {branch} not found in repo {self.repo_url}")
+        elif res.status_code >= 400:
+            error_msg = f"Got status code {res.status_code} when getting branch."
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        return dacite.from_dict(BranchAPIResponse, res.json())
+
+    @cached_property
+    def default_branch(self) -> str:
+        return self.get_repo_info().default_branch
+
+    @property
+    def last_commit(self, branch: Optional[str] = None) -> str:
+        if branch is None:
+            branch = self.default_branch
+        return self.get_branch_info(branch).commit.id
+
+    @cached_property
+    def repo_api_url(self) -> str:
+        """
+        Base URL for making all API request for the repos.
+        Format: https://dagshub.com/api/v1/repos/user/repo
+        """
+        return _multi_urljoin(
+            self.host,
+            "api/v1/repos",
+            self.owner,
+            self.repo_name,
+        )
+
+    @cached_property
+    def repo_url(self) -> str:
+        """
+        URL of the repo on DagsHub
+        Format: https://dagshub.com/user/repo
+        """
+        return _multi_urljoin(
+            self.host,
+            self.owner,
+            self.repo_name
+        )
+
+    def branch_url(self, branch) -> str:
+        """
+        URL of a branch on the repo
+        Format: https://dasghub.com/api/v1/repos/user/repo/branches/branch
+        """
+        return _multi_urljoin(
+            self.repo_api_url,
+            "branches",
+            branch
+        )
+
+    @staticmethod
+    def parse_repo(repo: str) -> Tuple[str, str]:
+        parts = repo.split("/")
+        if len(parts) != 2:
+            raise WrongRepoFormatError("repo needs to be in the format <repo-owner>/<repo-name>")
+        return tuple(parts)
+
+
+def _multi_urljoin(*parts):
+    """Shoutout to https://stackoverflow.com/a/55722792"""
+    return urljoin(parts[0] + "/", "/".join(quote_plus(part.strip("/"), safe="/") for part in parts[1:]))

--- a/dagshub/common/api/responses.py
+++ b/dagshub/common/api/responses.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, List
+
+
+@dataclass
+class RepoAPIResponse:
+    id: int
+    owner: "UserAPIResponse"
+    name: str
+    full_name: str
+    description: str
+    private: bool
+    fork: bool
+    parent: Optional["RepoAPIResponse"]
+    empty: bool
+    mirror: bool
+    size: int
+    html_url: str
+    ssh_url: Optional[str]
+    clone_url: str
+    website: Optional[str]
+    stars_count: int
+    forks_count: int
+    watchers_count: int
+    open_issues_count: int
+    default_branch: str
+    created_at: str
+    updated_at: str
+    permissions: Optional[Dict[str, bool]]
+
+
+@dataclass
+class UserAPIResponse:
+    id: int
+    login: str
+    full_name: str
+    avatar_url: str
+    public_email: str
+    website: str
+    company: str
+    description: str
+    username: str
+
+
+@dataclass
+class BranchAPIResponse:
+    name: str
+    commit: "CommitAPIResponse"
+
+
+@dataclass
+class CommitAPIResponse:
+    id: str
+    message: str
+    url: str
+    author: Optional["GitUser"]
+    committer: Optional["GitUser"]
+    added: Optional[List[str]]
+    removed: Optional[List[str]]
+    modified: Optional[List[str]]
+    timestamp: str
+
+
+@dataclass
+class GitUser:
+    name: str
+    email: str
+    username: str

--- a/dagshub/common/api/responses.py
+++ b/dagshub/common/api/responses.py
@@ -34,11 +34,11 @@ class UserAPIResponse:
     id: int
     login: str
     full_name: str
-    avatar_url: str
-    public_email: str
-    website: str
-    company: str
-    description: str
+    avatar_url: Optional[str]
+    public_email: Optional[str]
+    website:Optional[str]
+    company: Optional[str]
+    description: Optional[str]
     username: str
 
 

--- a/dagshub/common/api/responses.py
+++ b/dagshub/common/api/responses.py
@@ -1,5 +1,11 @@
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Optional, Dict, List
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 
 
 @dataclass
@@ -36,7 +42,7 @@ class UserAPIResponse:
     full_name: str
     avatar_url: Optional[str]
     public_email: Optional[str]
-    website:Optional[str]
+    website: Optional[str]
     company: Optional[str]
     description: Optional[str]
     username: str
@@ -66,3 +72,37 @@ class GitUser:
     name: str
     email: str
     username: str
+
+
+@dataclass
+class StorageAPIEntry:
+    name: str
+    protocol: str
+    list_path: str
+
+    @cached_property
+    def full_path(self):
+        return f"{self.protocol}/{self.name}"
+
+    @cached_property
+    def path_in_mount(self) -> PurePosixPath:
+        return PurePosixPath(".dagshub/storage") / self.protocol / self.name
+
+
+@dataclass
+class ContentAPIEntry:
+    path: str
+    # Possible values: dir, file, storage
+    type: str
+    size: int
+    hash: str
+    # Possible values: git, dvc, bucket
+    versioning: str
+    download_url: str
+    content_url: Optional[str]  # TODO: remove Optional once content_url is exposed in API
+
+
+@dataclass
+class StorageContentAPIResult:
+    entries: List[ContentAPIEntry]
+    next_token: Optional[str]

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -1,14 +1,11 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Any, List
+from typing import Optional, Any
 
 try:
     from functools import cached_property
 except ImportError:
     from cached_property import cached_property
-
-
-
 
 storage_schemas = ["s3", "gs"]
 

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -8,38 +8,6 @@ except ImportError:
     from cached_property import cached_property
 
 
-@dataclass
-class StorageAPIEntry:
-    name: str
-    protocol: str
-    list_path: str
-
-    @cached_property
-    def full_path(self):
-        return f"{self.protocol}/{self.name}"
-
-    @cached_property
-    def path_in_mount(self) -> Path:
-        return Path(".dagshub/storage") / self.protocol / self.name
-
-
-@dataclass
-class ContentAPIEntry:
-    path: str
-    # Possible values: dir, file, storage
-    type: str
-    size: int
-    hash: str
-    # Possible values: git, dvc, bucket
-    versioning: str
-    download_url: str
-    content_url: Optional[str]  # TODO: remove Optional once content_url is exposed in API
-
-
-@dataclass
-class StorageContentAPIResult:
-    entries: List[ContentAPIEntry]
-    next_token: Optional[str]
 
 
 storage_schemas = ["s3", "gs"]

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -616,7 +616,7 @@ class DagsHubFilesystem:
         if path.is_storage_path:
             path_to_access = str_path[len(".dagshub/storage/"):]
             return self._api.storage_content_api_url(path_to_access)
-        return self._api.content_api_url(self._current_revision, str_path)
+        return self._api.content_api_url(str_path, self._current_revision)
 
     def _raw_url_for_path(self, path: DagshubPath):
         if not path.is_in_repo:
@@ -625,7 +625,7 @@ class DagsHubFilesystem:
         if path.is_storage_path:
             path_to_access = str_path[len(".dagshub/storage/"):]
             return self._api.storage_raw_api_url(path_to_access)
-        return self._api.raw_api_url(self._current_revision, str_path)
+        return self._api.raw_api_url(str_path, self._current_revision)
 
     @staticmethod
     def _is_server_error(resp: Response):

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -11,14 +11,17 @@ from multiprocessing import AuthenticationError
 from os import PathLike
 from pathlib import Path
 from typing import Optional, TypeVar, Union, Dict, Set, Tuple, List, Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult
 import dacite
 from httpx import Response
 
 from dagshub.common import config, helpers
 import logging
+
+from dagshub.common.api.repo import RepoAPI, CommitNotFoundError
+from dagshub.common.api.responses import ContentAPIEntry, StorageContentAPIResult
 from dagshub.common.helpers import http_request, get_project_root
-from dagshub.streaming.dataclasses import StorageAPIEntry, ContentAPIEntry, DagshubPath, StorageContentAPIResult
+from dagshub.streaming.dataclasses import DagshubPath
 from dagshub.streaming.errors import FilesystemAlreadyMountedError
 
 # Pre 3.11 - need to patch _NormalAccessor for _pathlib, because it pre-caches open and other functions.
@@ -111,18 +114,15 @@ class DagsHubFilesystem:
         else:
             self.project_root_fd = os.open(self.project_root, os.O_DIRECTORY)
 
-        self.dagshub_remotes = []
-        self.parse_git_config()
-
         if not repo_url:
-            if len(self.dagshub_remotes) > 0:
-                repo_url = self.dagshub_remotes[0]
+            remotes = self.get_remotes_from_git_config()
+            if len(remotes) > 0:
+                repo_url = remotes[0]
             else:
                 raise ValueError('No DagsHub git remote detected, please specify repo_url= argument or --repo_url flag')
 
         self.user_specified_branch = branch
         self.parsed_repo_url = urlparse(repo_url)
-        self.dvc_remote_url = f'{repo_url}.dvc/cache'
         # Key: path, value: dict of {name, type} on that path (in remote)
         self.remote_tree: Dict[str, Dict[str, str]] = {}
 
@@ -134,6 +134,8 @@ class DagsHubFilesystem:
 
         self._listdir_cache: Dict[str, Optional[Tuple[List[ContentAPIEntry], bool]]] = {}
 
+        self._api = self._generate_repo_api(self.parsed_repo_url)
+
         self.check_project_root_use()
 
         # Check that the repo is accessible by accessing the content root
@@ -142,7 +144,12 @@ class DagsHubFilesystem:
             # TODO: Check .dvc/config{,.local} for credentials
             raise AuthenticationError('DagsHub credentials required, however none provided or discovered')
 
-        self._storages = self._api_storages()
+        self._storages = self._api.get_connected_storages()
+
+    def _generate_repo_api(self, repo_url: ParseResult) -> RepoAPI:
+        host = f"{repo_url.scheme}://{repo_url.netloc}"
+        repo = repo_url.path
+        return RepoAPI(repo=repo, host=host, auth=self.auth)
 
     @cached_property
     def _current_revision(self) -> str:
@@ -173,35 +180,15 @@ class DagsHubFilesystem:
             except FileNotFoundError:
                 logger.debug("Couldn't get branch info from local git repository, " +
                              "fetching default branch from the remote...")
-                owner, reponame = self.parsed_repo_url.path.split("/")[1:]
-                branch = helpers.get_default_branch(owner, reponame, self.auth)
-                logger.debug(f'Set default branch: "{branch}"')
-        return self.get_remote_branch_head(branch)
-
-    @property
-    def content_api_url(self):
-        return self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/content/{self._current_revision}")
-
-    @property
-    def raw_api_url(self):
-        return self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/raw/{self._current_revision}")
-
-    @property
-    def storage_api_url(self):
-        return self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/storage")
-
-    @property
-    def storage_content_api_url(self):
-        return f"{self.storage_api_url}/content"
-
-    @property
-    def storage_raw_api_url(self):
-        return f"{self.storage_api_url}/raw"
+                branch = self._api.default_branch
+        return self._api.last_commit_sha(branch)
 
     def is_commit_on_remote(self, sha1):
-        url = self.get_api_url(f"/api/v1/repos{self.parsed_repo_url.path}/commits/{sha1}")
-        resp = self.http_get(url)
-        return resp.status_code == 200
+        try:
+            self._api.get_commit_info(sha1)
+            return True
+        except CommitNotFoundError:
+            return False
 
     def check_project_root_use(self):
         """
@@ -229,9 +216,6 @@ class DagsHubFilesystem:
                                f"Response body: {resp.content}")
         return resp.json()["commit"]["id"]
 
-    def get_api_url(self, path):
-        return str(self.parsed_repo_url._replace(path=path).geturl())
-
     @property
     def auth(self):
         import dagshub.auth
@@ -256,19 +240,21 @@ class DagsHubFilesystem:
         if 'username' in answer and 'password' in answer:
             return answer['username'], answer['password']
 
-    def parse_git_config(self):
+    def get_remotes_from_git_config(self) -> List[str]:
         # Get URLs of dagshub remotes
         git_config = ConfigParser()
         git_config.read(Path(self.project_root) / '.git/config')
         git_remotes = [urlparse(git_config[remote]['url'])
                        for remote in git_config
                        if remote.startswith('remote ')]
+        res_remotes = []
         for remote in git_remotes:
             if remote.hostname != config.hostname:
                 continue
             remote = remote._replace(netloc=remote.hostname)
             remote = remote._replace(path=re.compile(r'(\.git)?/?$').sub('', remote.path))
-            self.dagshub_remotes.append(remote.geturl())
+            res_remotes.append(remote.geturl())
+        return res_remotes
 
     def __del__(self):
         if hasattr(self, "project_root_fd"):
@@ -605,14 +591,6 @@ class DagsHubFilesystem:
         self._listdir_cache[path.relative_path.as_posix()] = (res, include_size)
         return res
 
-    def _api_storages(self) -> List[StorageAPIEntry]:
-        response = self.http_get(self.storage_api_url)
-        if response.status_code >= 400:
-            logger.warning(f"Got HTTP code {response.status_code} while getting storages. Content: {response.content}")
-            logger.warning("Storages are unavailable")
-            return []
-        return [dacite.from_dict(StorageAPIEntry, storage_entry) for storage_entry in response.json()]
-
     def _check_listdir_cache(self, path: str, include_size: bool) -> Tuple[Optional[List[ContentAPIEntry]], bool]:
         # Checks that path has a pre-cached response
         # If include_size is True, but only a response without size is cached, that's a cache miss
@@ -628,8 +606,8 @@ class DagsHubFilesystem:
         str_path = path.relative_path.as_posix()
         if path.is_storage_path:
             path_to_access = str_path[len(".dagshub/storage/"):]
-            return f"{self.storage_content_api_url}/{path_to_access}"
-        return f"{self.content_api_url}/{str_path}"
+            return self._api.storage_content_api_url(path_to_access)
+        return self._api.content_api_url(self._current_revision, str_path)
 
     def _raw_url_for_path(self, path: DagshubPath):
         if not path.is_in_repo:
@@ -637,8 +615,8 @@ class DagsHubFilesystem:
         str_path = path.relative_path.as_posix()
         if path.is_storage_path:
             path_to_access = str_path[len(".dagshub/storage/"):]
-            return f"{self.storage_raw_api_url}/{path_to_access}"
-        return f"{self.raw_api_url}/{str_path}"
+            return self._api.storage_raw_api_url(path_to_access)
+        return self._api.raw_api_url(self._current_revision, str_path)
 
     def _api_download_file_git(self, path: DagshubPath):
         return self.http_get(self._raw_url_for_path(path), headers=config.requests_headers, timeout=None)

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -71,6 +71,10 @@ class dagshub_ScandirIterator:
 SPECIAL_FILE = Path(".dagshub-streaming")
 
 
+def _is_server_error(resp: Response):
+    return resp.status_code >= 500
+
+
 # TODO: Singleton metaclass that lets us keep a "main" DvcFilesystem instance
 class DagsHubFilesystem:
     """
@@ -626,10 +630,6 @@ class DagsHubFilesystem:
             path_to_access = str_path[len(".dagshub/storage/"):]
             return self._api.storage_raw_api_url(path_to_access)
         return self._api.raw_api_url(str_path, self._current_revision)
-
-    @staticmethod
-    def _is_server_error(resp: Response):
-        return resp.status_code >= 500
 
     @retry(retry=retry_if_result(_is_server_error), stop=stop_after_attempt(3),
            wait=wait_exponential(multiplier=1, min=4, max=10),

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -1,5 +1,6 @@
 import builtins
 import io
+import logging
 import os
 import re
 import subprocess
@@ -12,13 +13,12 @@ from os import PathLike
 from pathlib import Path
 from typing import Optional, TypeVar, Union, Dict, Set, Tuple, List, Any
 from urllib.parse import urlparse, ParseResult
+
 import dacite
 from httpx import Response
 from tenacity import retry, retry_if_result, stop_after_attempt, wait_exponential, before_sleep_log, RetryError
 
-from dagshub.common import config, helpers
-import logging
-
+from dagshub.common import config
 from dagshub.common.api.repo import RepoAPI, CommitNotFoundError
 from dagshub.common.api.responses import ContentAPIEntry, StorageContentAPIResult
 from dagshub.common.helpers import http_request, get_project_root

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -1,22 +1,22 @@
-import json
-import posixpath
-
-import urllib
-import os
-import logging
 import fnmatch
-from typing import Union, Tuple, BinaryIO, Dict
+import json
+import logging
+import os
+import posixpath
+import urllib
+from http import HTTPStatus
 from io import IOBase
+from typing import Union, Tuple, BinaryIO, Dict
+
 import httpx
 import rich.progress
 
-from dagshub.common import config, helpers, rich_console
-from http import HTTPStatus
 import dagshub.auth
 from dagshub.auth.token_auth import HTTPBearerAuth
+from dagshub.common import config, rich_console
 from dagshub.common.api.repo import RepoAPI
-from dagshub.upload.errors import determine_upload_api_error
 from dagshub.common.helpers import log_message
+from dagshub.upload.errors import determine_upload_api_error
 
 # todo: handle api urls in common package
 CONTENT_UPLOAD_URL = "api/v1/repos/{owner}/{reponame}/content/{branch}/{path}"

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -162,7 +162,7 @@ class Repo:
         """
         self.owner = owner
         self.name = name
-        self.src_url = config.host
+        self.host = config.host
 
         self.username = username or config.username
         self.password = password or config.password
@@ -320,7 +320,7 @@ class Repo:
 
         """
         return urllib.parse.urljoin(
-            self.src_url,
+            self.host,
             CONTENT_UPLOAD_URL.format(
                 owner=self.owner,
                 reponame=self.name,
@@ -340,7 +340,7 @@ class Repo:
 
         try:
             self.branch = helpers.get_default_branch(
-                self.owner, self.name, self.auth, self.src_url
+                self.owner, self.name, self.auth, self.host
             )
         except Exception:
             raise RuntimeError(
@@ -368,7 +368,7 @@ class Repo:
         :return: The commit id of the last commit for the branch
         """
         api_path = f"api/v1/repos/{self.full_name}/branches/{self.branch}"
-        api_url = urllib.parse.urljoin(self.src_url, api_path)
+        api_url = urllib.parse.urljoin(self.host, api_path)
         res = s.get(api_url, auth=self.auth)
         if res.status_code == HTTPStatus.OK:
             content = res.json()

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     "GitPython>=3.1.29",
     "rich[jupyter]~=13.1.0",
     "dacite~=1.8.0",
+    "tenacity~=8.2.2",
 ]
 
 # Polyfills for Python 3.7

--- a/tests/dda/upload/test_wrapper.py
+++ b/tests/dda/upload/test_wrapper.py
@@ -18,7 +18,7 @@ def test_file():
         pass
 
 
-def test_upload_dataset_closes_files(upload_repo: Repo, test_file: str):
+def test_upload_dataset_closes_files(mock_api, upload_repo: Repo, test_file: str):
     ds = upload_repo.directory("subdir")
     file_handle = open(test_file)
     ds.add(file_handle, "filepath.txt")


### PR DESCRIPTION
This PR consolidates a bunch of functionality that was implemented separately per "submodule".
Now the API to talk witih dagshub can be interacted with via a `RepoAPI` object, that has most stuff that is required.
The Upload wrapper and streaming DagsHubFileSystem are still used, but now use this RepoAPI where it makes sense.

Aside from that I added `tenacity` and use it in streaming to retry downloading files in case the server fails 