### PR TITLE
fix DagsHubFileSystem failing when project_root is not provided

### DIFF
--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -109,10 +109,13 @@ class DagsHubFilesystem:
             try:
                 self.project_root = get_project_root(Path(os.path.abspath('.')))
             except ValueError:
-                raise ValueError("Could not find a git repo. Either run the function inside of a git repo, "
-                                 "specify `project_root` with the path to a cloned DagsHub repository, "
-                                 "or specify `repo_url` (url of repo on DagsHub) and "
-                                 "`project_root` (path to the folder where to mount the filesystem) arguments")
+                if repo_url is not None:
+                    self.project_root = Path(os.path.abspath("."))
+                else:
+                    raise ValueError("Could not find a git repo. Either run the function inside of a git repo, "
+                                    "specify `project_root` with the path to a cloned DagsHub repository, "
+                                    "or specify `repo_url` (url of repo on DagsHub) and "
+                                    "`project_root` (path to the folder where to mount the filesystem) arguments")
 
         else:
             self.project_root = Path(os.path.abspath(project_root))


### PR DESCRIPTION
This PR makes this not fail:
![b9c2229e5542f17e78d9f36c4a8af7d6](https://github.com/DagsHub/client/assets/15911452/30b05a1c-e4d2-4961-af93-9ac711e6b41c)

Attempting to fix #318 