### PR TITLE
Fix default path on folder upload

### DIFF
--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -26,7 +26,6 @@ REPO_CREATE_URL = "api/v1/user/repos"
 ORG_REPO_CREATE_URL = "api/v1/org/{orgname}/repos"
 USER_INFO_URL = "api/v1/user"
 DEFAULT_DATA_DIR_NAME = 'data'
-DEFAULT_REMOTE_PATH = "/data/src/"
 logger = logging.getLogger(__name__)
 
 s = httpx.Client()
@@ -198,7 +197,15 @@ class Repo:
 
         """
         if os.path.isdir(local_path):
-            dir_to_upload = self.directory(remote_path if remote_path is not None else DEFAULT_REMOTE_PATH)
+            if remote_path is None:
+                abspath = os.path.abspath(local_path)
+                cwd = os.getcwd()
+                if abspath.startswith(cwd):
+                    remote_path = os.path.relpath(abspath, cwd)
+                else:
+                    remote_path = os.path.basename(abspath)
+            remote_path = remote_path.replace(os.sep, '/')
+            dir_to_upload = self.directory(remote_path)
             dir_to_upload.add_dir(local_path, commit_message=commit_message, **kwargs)
         else:
             file_to_upload = DataSet.get_file(local_path, remote_path)

--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -6,6 +6,7 @@ import posixpath
 import urllib
 from http import HTTPStatus
 from io import IOBase
+from pathlib import Path
 from typing import Union, Tuple, BinaryIO, Dict
 
 import httpx
@@ -181,7 +182,7 @@ class Repo:
         self,
         local_path: Union[str, IOBase],
         commit_message=DEFAULT_COMMIT_MESSAGE,
-        remote_path=None,
+        remote_path: str = None,
         **kwargs,
     ):
         """
@@ -189,26 +190,26 @@ class Repo:
         It takes a file as an argument and logs the response status code and content.
 
 
-        :param file (str): Specify the file to be uploaded
-        :param commit_message (str): Specify a commit message
-        :param path (str): Specify the path to upload the file to
+        :param local_path: Specify the file to be uploaded
+        :param commit_message: Specify a commit message
+        :param remote_path: Specify the path to upload the file to
         :param **kwargs: Pass in any additional parameters that are required for the upload function
         :return: None
 
         """
-        if os.path.isdir(local_path):
+        local_path = Path(local_path).resolve()
+        if local_path.is_dir():
             if remote_path is None:
-                abspath = os.path.abspath(local_path)
-                cwd = os.getcwd()
-                if abspath.startswith(cwd):
-                    remote_path = os.path.relpath(abspath, cwd)
-                else:
-                    remote_path = os.path.basename(abspath)
-            remote_path = remote_path.replace(os.sep, '/')
+                try:
+                    remote_path = local_path.relative_to(Path.cwd().resolve())
+                except ValueError:
+                    # local_path is outside cwd, use only its basename
+                    remote_path = local_path.name
+            remote_path = Path(remote_path).as_posix()
             dir_to_upload = self.directory(remote_path)
-            dir_to_upload.add_dir(local_path, commit_message=commit_message, **kwargs)
+            dir_to_upload.add_dir(str(local_path), commit_message=commit_message, **kwargs)
         else:
-            file_to_upload = DataSet.get_file(local_path, remote_path)
+            file_to_upload = DataSet.get_file(str(local_path), remote_path)
             self.upload_files([file_to_upload], commit_message=commit_message, **kwargs)
 
     def upload_files(

--- a/tests/dda/conftest.py
+++ b/tests/dda/conftest.py
@@ -1,35 +1,37 @@
 import os
 import pytest
+import pytest_git
+
 from tests.dda.mock_api import MockApi
 
 
 @pytest.fixture
-def repouser():
+def repouser() -> str:
     return "user"
 
 
 @pytest.fixture
-def reponame():
+def reponame() -> str:
     return "repo"
 
 
 @pytest.fixture
-def repopath(repouser, reponame):
+def repopath(repouser: str, reponame: str) -> str:
     return f"{repouser}/{reponame}"
 
 
 @pytest.fixture
-def repourl(repopath):
+def repourl(repopath: str) -> str:
     return f"https://dagshub.com/{repopath}"
 
 
 @pytest.fixture
-def current_revision(dagshub_repo):
+def current_revision(dagshub_repo: pytest_git.GitRepo) -> str:
     return dagshub_repo.api.heads.main.commit.hexsha
 
 
 @pytest.fixture
-def mock_api(dagshub_repo):
+def mock_api(dagshub_repo: pytest_git.GitRepo) -> MockApi:
     with MockApi(
         git_repo=dagshub_repo, base_url="https://dagshub.com", assert_all_called=False
     ) as respx_mock:
@@ -37,7 +39,7 @@ def mock_api(dagshub_repo):
 
 
 @pytest.fixture
-def dagshub_repo(git_repo, repopath):
+def dagshub_repo(git_repo: pytest_git.GitRepo, repopath: str) -> pytest_git.GitRepo:
     cwd = os.getcwd()
     os.chdir(git_repo.workspace)
     repo = git_repo.api

--- a/tests/dda/upload/conftest.py
+++ b/tests/dda/upload/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 
 from dagshub.upload import Repo
+from tests.dda.mock_api import MockApi
 
 
 @pytest.fixture
-def upload_repo(repouser, reponame, mock_api):
+def upload_repo(repouser: str, reponame: str, mock_api: MockApi) -> Repo:
     mock_api.enable_uploads()
     repo = Repo(repouser, reponame)
     yield repo

--- a/tests/dda/upload/test_wrapper.py
+++ b/tests/dda/upload/test_wrapper.py
@@ -1,13 +1,15 @@
 import os
+import tempfile
 import uuid
 
 import pytest
 
 from dagshub.upload import Repo
+from tests.dda.mock_api import MockApi
 
 
 @pytest.fixture(scope="function")
-def test_file():
+def test_file() -> str:
     filepath = f"{uuid.uuid4()}.txt"
     with open(filepath, "w") as f:
         f.write("test data")
@@ -18,9 +20,82 @@ def test_file():
         pass
 
 
-def test_upload_dataset_closes_files(mock_api, upload_repo: Repo, test_file: str):
+@pytest.fixture(scope="function")
+def test_dirs() -> str:
+    folder_path = os.path.join("nested", "folder")
+    os.makedirs(folder_path, exist_ok=True)
+
+    filepath1 = os.path.join(folder_path, f"{uuid.uuid4()}.txt")
+    with open(filepath1, "w") as f:
+        f.write("test data")
+    filepath2 = os.path.join(folder_path, f"{uuid.uuid4()}.txt")
+    with open(filepath2, "w") as f:
+        f.write("test data")
+
+    yield folder_path
+    try:
+        os.remove(filepath1)
+        os.remove(filepath2)
+        os.removedirs(folder_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture(scope="function")
+def temp_dir() -> str:
+    # Create a temporary directory
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Define the nested folder path
+        folder_path = os.path.join(temp_dir, "nested", "foldername")
+
+        # Create the nested folder
+        os.makedirs(folder_path, exist_ok=True)
+
+        file_path = os.path.join(folder_path, "example_file.txt")
+        with open(file_path, "w") as file:
+            file.write("This is an example file.")
+
+        yield folder_path
+        try:
+            os.remove(file_path)
+            os.removedirs(folder_path)
+        except OSError:
+            pass
+
+
+def test_upload_dataset_closes_files(mock_api: MockApi, upload_repo: Repo, test_file: str):
     ds = upload_repo.directory("subdir")
     file_handle = open(test_file)
     ds.add(file_handle, "filepath.txt")
     ds.commit()
     assert file_handle.closed
+
+
+def test_upload_folder_preserves_relative_path(mock_api: MockApi, upload_repo: Repo, test_dirs: str):
+    do_upload_folder_test(mock_api, test_dirs, test_dirs, upload_repo)
+
+
+def test_upload_folder_absolute_path_can_be_relative(mock_api: MockApi, upload_repo: Repo, test_dirs: str):
+    abspath = os.path.abspath(test_dirs)
+    do_upload_folder_test(mock_api, abspath, test_dirs, upload_repo)
+
+
+def do_upload_folder_test(mock_api: MockApi, src_dirs: str, dst_dirs: str, upload_repo: Repo):
+    upload_repo.upload(local_path=src_dirs)
+    upload_route = mock_api.routes['upload']
+    upload_route.calls.assert_called_once()
+    call = upload_route.calls.last
+    assert call.response.status_code == 200
+    assert call.request.method == 'PUT'
+    expected = f'/api/v1/repos/{upload_repo.owner}/{upload_repo.name}/content/{upload_repo.branch}/{dst_dirs}'
+    assert call.request.url.path == expected
+
+
+def test_upload_folder_absolute_path_outside_cwd(mock_api: MockApi, upload_repo: Repo, temp_dir: str):
+    do_upload_folder_test(mock_api, temp_dir, "foldername", upload_repo)
+
+
+def test_upload_folder_relative_path_outside_cwd(mock_api: MockApi, upload_repo: Repo, temp_dir: str):
+    relpath = os.path.relpath(temp_dir, os.getcwd())
+    assert relpath.startswith('..')
+    do_upload_folder_test(mock_api, relpath, "foldername", upload_repo)

--- a/tests/dda/upload/test_wrapper.py
+++ b/tests/dda/upload/test_wrapper.py
@@ -56,11 +56,6 @@ def temp_dir() -> str:
             file.write("This is an example file.")
 
         yield folder_path
-        try:
-            os.remove(file_path)
-            os.removedirs(folder_path)
-        except (OSError, FileNotFoundError):
-            pass
 
 
 def test_upload_dataset_closes_files(mock_api: MockApi, upload_repo: Repo, test_file: str):

--- a/tests/dda/upload/test_wrapper.py
+++ b/tests/dda/upload/test_wrapper.py
@@ -16,7 +16,7 @@ def test_file() -> str:
     yield filepath
     try:
         os.remove(filepath)
-    except OSError:
+    except (OSError, FileNotFoundError):
         pass
 
 
@@ -37,7 +37,7 @@ def test_dirs() -> str:
         os.remove(filepath1)
         os.remove(filepath2)
         os.removedirs(folder_path)
-    except OSError:
+    except (OSError, FileNotFoundError):
         pass
 
 
@@ -59,7 +59,7 @@ def temp_dir() -> str:
         try:
             os.remove(file_path)
             os.removedirs(folder_path)
-        except OSError:
+        except (OSError, FileNotFoundError):
             pass
 
 


### PR DESCRIPTION
It used to always be /data/src which is unexpected. Instead, set it to something more predictable - the relative folder path or at least its basename