### PR TITLE
Check HTTP status 204 on file uploads

### DIFF
--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -295,10 +295,12 @@ class Repo:
         )
         self._log_upload_details(data, res, files)
 
-    def _log_upload_details(self, data, res, files):
+    @staticmethod
+    def _log_upload_details(data, res, files):
         """
         The _log_upload_details function logs the request URL, data, and files.
-        It then logs the response status code and content. If the response is not 200(OK), it raises an error.
+        It then logs the response status code and content.
+        If the response is not 200(OK), or 204(NoContent) it raises an error.
 
 
 
@@ -315,10 +317,12 @@ class Repo:
             f"Files:\n{json.dumps(list(map(str, files)), indent=4)}"
         )
 
-        if res.status_code != HTTPStatus.OK:
-            raise determine_upload_api_error(res)
-        else:
+        if res.status_code == HTTPStatus.OK:
             log_message("Upload finished successfully!", logger)
+        elif res.status_code == HTTPStatus.NO_CONTENT:
+            log_message("Upload successful, content was identical and no new commit was created", logger)
+        else:
+            raise determine_upload_api_error(res)
 
     @property
     def auth(self):


### PR DESCRIPTION
Indicates that although files were uploaded, their content was identical to what was already on the server, and so nothing was changed.

This can be further improved by returning a boolean indicating whether something changed or not, and using that to determine whether a repo sync is necessary before uploading more files.