### PR TITLE
Token handling enhancements

### DIFF
--- a/dagshub/auth/__init__.py
+++ b/dagshub/auth/__init__.py
@@ -1,4 +1,4 @@
-from .tokens import get_token, add_app_token, add_oauth_token, InvalidTokenError
+from .tokens import get_token, add_app_token, add_oauth_token, InvalidTokenError, get_authenticator
 from .oauth import OauthNonInteractiveShellException
 
 __all__ = [
@@ -7,4 +7,5 @@ __all__ = [
     add_oauth_token.__name__,
     OauthNonInteractiveShellException.__name__,
     InvalidTokenError.__name__,
+    get_authenticator.__name__,
 ]

--- a/dagshub/auth/oauth.py
+++ b/dagshub/auth/oauth.py
@@ -6,6 +6,7 @@ import uuid
 import httpx
 import webbrowser
 
+from dagshub.auth.token_auth import OauthDagshubToken
 from dagshub.common import config, rich_console
 
 logger = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 def oauth_flow(
     host: str,
     client_id: Optional[str] = None
-) -> Dict:
+) -> OauthDagshubToken:
 
     host = host.strip("/")
     dagshub_url = urllib.parse.urljoin(host, "login/oauth")
@@ -56,7 +57,7 @@ def oauth_flow(
         raise Exception(
             f"Error while getting OAuth token: HTTP {res.status_code}, Body: {res.json()}"
         )
-    token = res.json()
+    token = OauthDagshubToken.deserialize(res.json())
 
     logger.debug(f"Got token: {token}")
     return token

--- a/dagshub/auth/oauth.py
+++ b/dagshub/auth/oauth.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import Optional, Dict
+from typing import Optional
 import logging
 import urllib
 import uuid

--- a/dagshub/auth/oauth.py
+++ b/dagshub/auth/oauth.py
@@ -6,7 +6,7 @@ import uuid
 import httpx
 import webbrowser
 
-from dagshub.auth.token_auth import OauthDagshubToken
+from dagshub.auth.token_auth import OAuthDagshubToken
 from dagshub.common import config, rich_console
 
 logger = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 def oauth_flow(
     host: str,
     client_id: Optional[str] = None
-) -> OauthDagshubToken:
+) -> OAuthDagshubToken:
 
     host = host.strip("/")
     dagshub_url = urllib.parse.urljoin(host, "login/oauth")
@@ -57,7 +57,7 @@ def oauth_flow(
         raise Exception(
             f"Error while getting OAuth token: HTTP {res.status_code}, Body: {res.json()}"
         )
-    token = OauthDagshubToken.deserialize(res.json())
+    token = OAuthDagshubToken.deserialize(res.json())
 
     logger.debug(f"Got token: {token}")
     return token

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -64,6 +64,8 @@ class OAuthDagshubToken(DagshubTokenABC):
         self.token_value = token_value
         self.expiry_date = expiry_date
 
+    # TODO: override the call function to warn about how much lifetime the token has
+
     def serialize(self) -> Dict[str, Any]:
         return {
             "access_token": self.token_value,
@@ -121,6 +123,33 @@ class AppDagshubToken(DagshubTokenABC):
 
     def __repr__(self):
         return "Dagshub App token"
+
+
+class EnvVarDagshubToken(DagshubTokenABC):
+    token_type = "env-var"
+    priority = -1
+
+    def __init__(self, token_value: str, host: str):
+        self.token_value = token_value
+        self.host = host
+
+    def serialize(self) -> Dict[str, Any]:
+        raise RuntimeError("Can't serialize env var token")
+
+    @staticmethod
+    def deserialize(values: Dict[str, Any]):
+        raise RuntimeError("Can't deserialize env var token")
+
+    @property
+    def token_text(self) -> str:
+        return self.token_value
+
+    @property
+    def is_expired(self) -> bool:
+        return False
+
+    def __repr__(self):
+        return f"Dagshub Env Var token for host {self.host}"
 
 
 class HTTPBearerAuth(Auth):

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -1,9 +1,11 @@
 import datetime
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, Generator, TYPE_CHECKING
+from typing import Any, Dict, Generator, TYPE_CHECKING, Optional
 
 import dateutil.parser
 from httpx import Request, Response, Auth
+
+from dagshub.common import config
 
 if TYPE_CHECKING:
     from dagshub.auth.tokens import TokenStorage
@@ -134,9 +136,9 @@ class EnvVarDagshubToken(DagshubTokenABC):
     token_type = "env-var"
     priority = -1
 
-    def __init__(self, token_value: str, host: str):
+    def __init__(self, token_value: str, host: Optional[str] = None):
         self.token_value = token_value
-        self.host = host
+        self.host = host or config.host
 
     def serialize(self) -> Dict[str, Any]:
         raise RuntimeError("Can't serialize env var token")

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -35,7 +35,7 @@ class DagshubAuthenticator(Auth):
         """
         # TODO: NEED TO COME UP WITH A WAY TO RENEGOTIATE HERE SOMEHOW
         # PROBABLY NEED TO CHECK FOR requests' REQUEST HERE
-        self._token(request)
+        return self._token(request)
 
 
 class TokenDeserializationError(Exception):

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -15,13 +15,17 @@ class DagshubAuthenticator(Auth):
     """
 
     def __init__(self, token: "DagshubTokenABC", token_storage: "TokenStorage", host: str):
-        self.token = token
-        self.token_storage = token_storage
-        self.host = host
+        self._token = token
+        self._token_storage = token_storage
+        self._host = host
 
     def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
         # TODO: failure mode recovery
-        yield self.token(request)
+        yield self._token(request)
+
+    @property
+    def token_text(self) -> str:
+        return self._token.token_text
 
 
 class TokenDeserializationError(Exception):

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -14,9 +14,10 @@ class DagshubAuthenticator(Auth):
     This class contains a token + flow on how to re-init the token in case of failure
     """
 
-    def __init__(self, token: "DagshubTokenABC", token_storage: "TokenStorage"):
+    def __init__(self, token: "DagshubTokenABC", token_storage: "TokenStorage", host: str):
         self.token = token
         self.token_storage = token_storage
+        self.host = host
 
     def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
         # TODO: failure mode recovery

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -29,6 +29,14 @@ class DagshubAuthenticator(Auth):
     def token_text(self) -> str:
         return self._token.token_text
 
+    def __call__(self, request):
+        """
+        Forward the call to the token
+        """
+        # TODO: NEED TO COME UP WITH A WAY TO RENEGOTIATE HERE SOMEHOW
+        # PROBABLY NEED TO CHECK FOR requests' REQUEST HERE
+        self._token(request)
+
 
 class TokenDeserializationError(Exception):
     ...
@@ -36,8 +44,7 @@ class TokenDeserializationError(Exception):
 
 class DagshubTokenABC(metaclass=ABCMeta):
     token_type = "NONE"
-    # Decides which token is giving out first to the user
-    priority = 10000
+    priority = 10000  # Decides which token is given out first to the user
 
     def __call__(self, request: Request) -> Request:
         request.headers["Authorization"] = f"Bearer {self.token_text}"

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -1,5 +1,73 @@
-import typing
+from abc import ABCMeta, abstractmethod
+from typing import Any, Dict, Generator, TYPE_CHECKING
+
 from httpx import Request, Response, Auth
+
+if TYPE_CHECKING:
+    from dagshub.auth.tokens import TokenStorage
+
+
+class DagshubAuthenticator(Auth):
+    """
+    This class contains a token + flow on how to re-init the token in case of failure
+    """
+
+    def __init__(self, token: "DagshubTokenABC", token_storage: "TokenStorage"):
+        self.token = token
+        self.token_storage = token_storage
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        # TODO: failure mode recovery
+        yield self.token(request)
+
+
+class DagshubTokenABC(metaclass=ABCMeta):
+    token_type = "NONE"
+
+    def __call__(self, request: Request) -> Request:
+        request.headers["Authorization"] = f"Bearer {self.token_text}"
+        return request
+
+    @abstractmethod
+    def deserialize(self, values: Dict[str, Any]):
+        ...
+
+    @abstractmethod
+    def serialize(self) -> Dict[str, Any]:
+        ...
+
+    @abstractmethod
+    @property
+    def token_text(self) -> str:
+        ...
+
+
+class OauthDagshubToken(DagshubTokenABC):
+    token_type = "bearer"
+
+    def serialize(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def deserialize(self, values: Dict[str, Any]):
+        raise NotImplementedError
+
+    @property
+    def token_text(self) -> str:
+        raise NotImplementedError
+
+
+class AppDagshubToken(DagshubTokenABC):
+    token_type = "app-token"
+
+    def serialize(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def deserialize(self, values: Dict[str, Any]):
+        raise NotImplementedError
+
+    @property
+    def token_text(self) -> str:
+        raise NotImplementedError
 
 
 class HTTPBearerAuth(Auth):
@@ -8,7 +76,7 @@ class HTTPBearerAuth(Auth):
     def __init__(self, token):
         self.token = token
 
-    def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
         request.headers["Authorization"] = f"Bearer {self.token}"
         yield request
 

--- a/dagshub/auth/tokens.py
+++ b/dagshub/auth/tokens.py
@@ -3,14 +3,13 @@ import logging
 import os
 import threading
 import traceback
-from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from typing import Optional, Dict, List, Set
+from typing import Optional, Dict, List, Set, Union
 
 import yaml
 
 from dagshub.auth import oauth
-from dagshub.auth.token_auth import HTTPBearerAuth, DagshubTokenABC
+from dagshub.auth.token_auth import HTTPBearerAuth, DagshubTokenABC, TokenDeserializationError, AppDagshubToken
 from dagshub.common import config
 from dagshub.common.helpers import http_request
 from dagshub.common.util import multi_urljoin
@@ -29,7 +28,8 @@ class TokenStorage:
     def __init__(self, cache_location: str = None, **kwargs):
         cache_location = cache_location or config.cache_location
         self.cache_location = cache_location
-        self.__token_cache: Optional[Dict[str, List[Dict]]] = None
+        self.schema_version = config.TOKENS_CACHE_SCHEMA_VERSION
+        self.__token_cache: Optional[Dict[str, List[DagshubTokenABC]]] = None
 
         # We check tokens only once for validity, so we don't do a lot of redundant requests
         #   maybe there is a point to re-evaluate them once in a while
@@ -49,7 +49,7 @@ class TokenStorage:
         for host, tokens in self._token_cache.items():
             if host == "version":
                 continue
-            expired_tokens = [t for t in tokens if self._is_expired(t)]
+            expired_tokens = filter(lambda token: token.is_expired, tokens)
             for t in expired_tokens:
                 had_changes = True
                 tokens.remove(t)
@@ -57,11 +57,11 @@ class TokenStorage:
             logger.info("Removed expired tokens from the token cache")
             self._store_cache_file()
 
-    def add_token(self, token: Dict, host: str = None, skip_validation=False):
+    def add_token(self, token: DagshubTokenABC, host: str = None, skip_validation=False):
         host = host or config.host
 
         if not skip_validation:
-            if not TokenStorage.is_valid_token(token["access_token"], host):
+            if not TokenStorage.is_valid_token(token.token_text, host):
                 raise InvalidTokenError
 
         if host not in self._token_cache:
@@ -163,25 +163,6 @@ class TokenStorage:
         is_expired = expiry_dt < datetime.datetime.utcnow()
         return is_expired
 
-    def _load_cache_file(self) -> Dict[str, List[Dict]]:
-        logger.debug(f"Loading OAuth token cache from {self.cache_location}")
-        if not os.path.exists(self.cache_location):
-            logger.debug("OAuth token cache file doesn't exist")
-            return self._get_empty_cache_dict()
-        try:
-            with open(self.cache_location) as f:
-                tokens_cache = yaml.load(f, yaml.Loader)
-                return tokens_cache
-        except Exception:
-            logger.error(
-                f"Error while loading DagsHub OAuth token cache: {traceback.format_exc()}"
-            )
-            raise
-
-    @staticmethod
-    def _get_empty_cache_dict():
-        return {"version": config.TOKENS_CACHE_SCHEMA_VERSION}
-
     @staticmethod
     def is_valid_token(token: str, host: str) -> bool:
         """
@@ -205,14 +186,58 @@ class TokenStorage:
         except AssertionError:
             return False
 
+    def _load_cache_file(self) -> Dict[str, List[DagshubTokenABC]]:
+        logger.debug(f"Loading OAuth token cache from {self.cache_location}")
+        if not os.path.exists(self.cache_location):
+            logger.debug("OAuth token cache file doesn't exist")
+            return {}
+        try:
+            with open(self.cache_location) as f:
+                cache_yaml = yaml.load(f, yaml.Loader)
+                version = cache_yaml.get("version", "1")
+                if version == "1":
+                    return self._v1_token_list_parser(cache_yaml)
+                raise RuntimeError(f"Don't know how to parse token schema {version}")
+        except Exception:
+            logger.error(
+                f"Error while loading DagsHub OAuth token cache: {traceback.format_exc()}"
+            )
+            raise
+
+    @staticmethod
+    def _v1_token_list_parser(cache_yaml: Dict[str, Union[str, List[Dict]]]) -> Dict[str, List[DagshubTokenABC]]:
+        res = {}
+
+        token_class_map = {}
+        for token_class in DagshubTokenABC.__subclasses__():
+            token_class_map[token_class.token_type] = token_class
+
+        for host, tokens in cache_yaml.items():
+            if host == "version":
+                continue
+            if len(tokens) == 0:
+                continue
+            host_tokens = []
+            for token_dict in tokens:
+                try:
+                    token = token_class_map[token_dict["token_type"]].deserialize(token_dict)
+                    host_tokens.append(token)
+                except TokenDeserializationError as e:
+                    logger.warning(f"Failed to deserialize token {token_dict}: {e}")
+            res[host] = host_tokens
+        return res
+
     def _store_cache_file(self):
         logger.debug(f"Dumping OAuth token cache to {self.cache_location}")
         try:
             dirpath = os.path.dirname(self.cache_location)
             if not os.path.exists(dirpath):
                 os.makedirs(dirpath)
+            dict_to_dump = {"version": self.schema_version}
+            for host, tokens in self.__token_cache.items():
+                dict_to_dump[host] = [t.serialize() for t in tokens]
             with open(self.cache_location, "w") as f:
-                yaml.dump(self.__token_cache, f, yaml.Dumper)
+                yaml.dump(dict_to_dump, f, yaml.Dumper)
         except Exception:
             logger.error(
                 f"Error while storing DagsHub OAuth token cache: {traceback.format_exc()}"
@@ -249,12 +274,8 @@ def add_app_token(token: str, host: Optional[str] = None, **kwargs):
     Adds an application token to the token cache.
     This is a long-lived token that you can add/revoke in your profile settings on DagsHub
     """
-    token_dict = {
-        "access_token": token,
-        "token_type": APP_TOKEN_TYPE,
-        "expiry": "never",
-    }
-    _get_token_storage(**kwargs).add_token(token_dict, host)
+    token_obj = AppDagshubToken(token)
+    _get_token_storage(**kwargs).add_token(token_obj, host)
 
 
 def add_oauth_token(host: Optional[str] = None, **kwargs):

--- a/dagshub/auth/tokens.py
+++ b/dagshub/auth/tokens.py
@@ -58,8 +58,11 @@ class TokenStorage:
             logger.info("Removed expired tokens from the token cache")
             self._store_cache_file()
 
-    def add_token(self, token: DagshubTokenABC, host: str = None, skip_validation=False):
+    def add_token(self, token: Union[str, DagshubTokenABC], host: str = None, skip_validation=False):
         host = host or config.host
+
+        if type(token) is str:
+            token = AppDagshubToken(token)
 
         if self._token_already_exists(token.token_text, host):
             logger.warning("The added token already exists in the token cache, skipping")

--- a/dagshub/auth/tokens.py
+++ b/dagshub/auth/tokens.py
@@ -11,7 +11,7 @@ from httpx import Auth
 
 from dagshub.auth import oauth
 from dagshub.auth.token_auth import HTTPBearerAuth, DagshubTokenABC, TokenDeserializationError, AppDagshubToken, \
-    EnvVarDagshubToken
+    EnvVarDagshubToken, DagshubAuthenticator
 from dagshub.common import config
 from dagshub.common.helpers import http_request
 from dagshub.common.util import multi_urljoin
@@ -75,7 +75,9 @@ class TokenStorage:
         """
         Returns the authenticator object, that can renegotiate tokens in case of failure
         """
-        raise NotImplementedError
+        host = host or config.host
+        token = self.get_token_object(host, fail_if_no_token, **kwargs)
+        return DagshubAuthenticator(token, token_storage=self, host=host)
 
     def get_token_object(self, host: str = None, fail_if_no_token: bool = False, **kwargs) -> DagshubTokenABC:
         """

--- a/dagshub/auth/tokens.py
+++ b/dagshub/auth/tokens.py
@@ -71,7 +71,7 @@ class TokenStorage:
         self._token_cache[host].append(token)
         self._store_cache_file()
 
-    def get_authenticator(self, host: str = None, fail_if_no_token: bool = False, **kwargs):
+    def get_authenticator(self, host: str = None, fail_if_no_token: bool = False, **kwargs) -> DagshubAuthenticator:
         """
         Returns the authenticator object, that can renegotiate tokens in case of failure
         """
@@ -269,7 +269,7 @@ def _get_token_storage(**kwargs):
     return _token_storage
 
 
-def get_authenticator(**kwargs):
+def get_authenticator(**kwargs) -> DagshubAuthenticator:
     """
     Get an authenticator object.
     This object can be used as auth argument for the httpx requests

--- a/dagshub/auth/tokens.py
+++ b/dagshub/auth/tokens.py
@@ -178,7 +178,6 @@ class TokenStorage:
                 return True
         return False
 
-
     @staticmethod
     def _is_expired(token: Dict[str, str]) -> bool:
         if "expiry" not in token:

--- a/dagshub/common/analytics.py
+++ b/dagshub/common/analytics.py
@@ -20,7 +20,7 @@ def send_analytics_event(event_name: str, repo: Optional[Union[int, "RepoAPI"]] 
         else:
             event_data["repo_id"] = repo.id
     host = config.host
-    token = config.token or get_token(host=host)
+    token = get_token(host=host)
     t = Thread(target=_send, args=(event_data, host, token), daemon=True)
     t.start()
 

--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -14,7 +14,6 @@ from typing import Optional, Tuple, Any, List
 import dacite
 
 import dagshub.auth
-from dagshub.auth.token_auth import HTTPBearerAuth
 from dagshub.common import config
 
 from dagshub.common.helpers import http_request

--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -56,7 +56,7 @@ class RepoAPI:
         self.host = host if host is not None else config.host
 
         if auth is None:
-            self.auth = HTTPBearerAuth(config.token or dagshub.auth.get_token(host=self.host))
+            self.auth = dagshub.auth.get_authenticator(host=host)
         else:
             self.auth = auth
 

--- a/dagshub/common/download.py
+++ b/dagshub/common/download.py
@@ -8,6 +8,8 @@ from typing import Tuple, Callable, Optional, List, Union, Dict
 
 from httpx import Auth
 
+from dagshub.common import config
+
 try:
     from typing import Literal
 except ImportError:

--- a/dagshub/data_engine/client/data_client.py
+++ b/dagshub/data_engine/client/data_client.py
@@ -8,7 +8,6 @@ from gql.transport.requests import RequestsHTTPTransport
 
 import dagshub.auth
 import dagshub.common.config
-from dagshub.auth.token_auth import HTTPBearerAuth
 from dagshub.common import config
 from dagshub.common.analytics import send_analytics_event
 from dagshub.common.rich_util import get_rich_progress
@@ -39,7 +38,7 @@ class DataClient:
 
     def _init_client(self):
         url = f"{self.host}/api/v1/repos/{self.repo}/data-engine/graphql"
-        auth = HTTPBearerAuth(config.token or dagshub.auth.get_token(host=self.host))
+        auth = dagshub.auth.get_authenticator(host=self.host)
         transport = RequestsHTTPTransport(url=url, auth=auth)
         client = gql.Client(transport=transport)
         return client

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -219,6 +219,7 @@ class QueryResult:
             cache_on_disk: Whether to cache the blobs on disk or not (valid only if load_into_memory is set to True)
                 Cache location is `~/dagshub/datasets/<user>/<repo>/<datasource_id>/.metadata_blobs/`
         """
+        send_analytics_event("Client_DataEngine_downloadBlobs", repo=self.datasource.source.repoApi)
         if not load_into_memory:
             assert cache_on_disk
         for fld in fields:
@@ -245,9 +246,8 @@ class QueryResult:
     def download_binary_columns(self, *columns: str, load_into_memory=True,
                                 cache_on_disk=True, num_proc: int = 32) -> "QueryResult":
         """
-        deprecated: Use get_blob_columns instead.
+        deprecated: Use get_blob_fields instead.
         """
-        send_analytics_event("Client_DataEngine_downloadBlobs", repo=self.datasource.source.repoApi)
         return self.get_blob_fields(*columns, load_into_memory=load_into_memory, cache_on_disk=cache_on_disk,
                                     num_proc=num_proc)
 

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -234,17 +234,14 @@ class DagsHubFilesystem:
     @property
     def auth(self):
         import dagshub.auth
-        from dagshub.auth.token_auth import HTTPBearerAuth
 
         if self.username is not None and self.password is not None:
             return self.username, self.password
 
         try:
-            token = self.token or dagshub.auth.get_token()
+            return dagshub.auth.get_authenticator()
         except dagshub.auth.OauthNonInteractiveShellException:
             logger.debug("Failed to perform OAuth in a non interactive shell")
-        if token is not None:
-            return HTTPBearerAuth(token)
 
         # Try to fetch credentials from the git credential file
         proc = subprocess.run(['git', 'credential', 'fill'],

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ install_requires = [
     "pandas",
     "treelib~=1.6.4",
     "pathvalidate~=3.0.0",
+    "python-dateutil",
 ]
 
 # Polyfills for Python 3.7

--- a/tests/dda/test_tokens.py
+++ b/tests/dda/test_tokens.py
@@ -27,7 +27,10 @@ def valid_token_side_effect(request: httpx.Request) -> httpx.Response:
 
 @pytest.fixture
 def token_api(mock_api):
-    dagshub.common.config.token = None  # Disable the env var token for these tests explicitly
+    # Disable the env var token for these tests explicitly
+    old_token_val = dagshub.common.config.token
+    dagshub.common.config.token = None
+
     mock_api.get("https://dagshub.com/api/v1/user").mock(side_effect=valid_token_side_effect)
 
     mock_api.post("https://dagshub.com/api/v1/middleman").mock(httpx.Response(200, json="code"))
@@ -40,6 +43,8 @@ def token_api(mock_api):
     }
     mock_api.post("https://dagshub.com/api/v1/access_token").mock(httpx.Response(200, json=good_auth_token))
     yield mock_api
+
+    dagshub.common.config.token = old_token_val
 
 
 @pytest.fixture

--- a/tests/dda/test_tokens.py
+++ b/tests/dda/test_tokens.py
@@ -1,10 +1,10 @@
 import datetime
 
+import dateutil.parser
 import httpx
+import pytest
 
 import dagshub.common.config
-import dateutil.parser
-import pytest
 from dagshub.auth.token_auth import AppDagshubToken, DagshubTokenABC, OAuthDagshubToken, EnvVarDagshubToken
 from dagshub.auth.tokens import (
     TokenStorage,

--- a/tests/dda/test_tokens.py
+++ b/tests/dda/test_tokens.py
@@ -1,0 +1,145 @@
+import datetime
+
+import httpx
+
+import dagshub.common.config
+import dateutil.parser
+import pytest
+from dagshub.auth.token_auth import AppDagshubToken, DagshubTokenABC, OAuthDagshubToken, EnvVarDagshubToken
+from dagshub.auth.tokens import (
+    TokenStorage,
+    InvalidTokenError,
+)
+
+
+def valid_token_side_effect(request: httpx.Request) -> httpx.Response:
+    if request.headers["Authorization"] == "Bearer good-token":
+        return httpx.Response(200, json={
+            "id": 1,
+            "login": "user",
+            "full_name": "user",
+            "avatar_url": "random_url",
+            "username": "user",
+        })
+    else:
+        return httpx.Response(401)
+
+
+@pytest.fixture
+def token_api(mock_api):
+    dagshub.common.config.token = None  # Disable the env var token for these tests explicitly
+    mock_api.get("https://dagshub.com/api/v1/user").mock(side_effect=valid_token_side_effect)
+
+    mock_api.post("https://dagshub.com/api/v1/middleman").mock(httpx.Response(200, json="code"))
+
+    a_day_away = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    good_auth_token = {
+        "access_token": "good-token",
+        "expiry": a_day_away.isoformat(),
+        "token_type": "bearer",
+    }
+    mock_api.post("https://dagshub.com/api/v1/access_token").mock(httpx.Response(200, json=good_auth_token))
+    yield mock_api
+
+
+@pytest.fixture
+def token_cache(token_api, tmp_path) -> TokenStorage:
+    cache_file = tmp_path / "tokens"
+    storage = TokenStorage(cache_location=str(cache_file.absolute()))
+    yield storage
+
+
+@pytest.fixture
+def valid_token() -> DagshubTokenABC:
+    return AppDagshubToken("good-token")
+
+
+@pytest.fixture
+def invalid_token() -> DagshubTokenABC:
+    return AppDagshubToken("fake-token")
+
+
+@pytest.fixture
+def expired_token() -> DagshubTokenABC:
+    old_date = dateutil.parser.parse("1990-01-01T16:24:53.451259Z")
+    return OAuthDagshubToken("fake-token", old_date)
+
+
+def test_no_token_fails_if_set_to_fail(token_cache):
+    with pytest.raises(RuntimeError):
+        token_cache.get_token(fail_if_no_token=True)
+
+
+def test_cant_add_invalid_token(token_cache, invalid_token):
+    with pytest.raises(InvalidTokenError):
+        token_cache.add_token(invalid_token)
+
+
+def test_can_add_valid_token(token_cache, valid_token):
+    # Assume there is a known good token in the regular get_token flow
+    token_cache.add_token(valid_token)
+
+
+def test_expired_token_gets_cleaned_up(token_cache, expired_token):
+    token_cleanup_test(token_cache, expired_token)
+
+
+def test_invalid_token_gets_cleaned_up(token_cache, invalid_token):
+    token_cleanup_test(token_cache, invalid_token)
+
+
+def token_cleanup_test(token_cache, token):
+    token_cache.add_token(token, skip_validation=True)
+
+    with pytest.raises(RuntimeError):
+        token_cache.get_token(fail_if_no_token=True)
+    # Also call this to remove expired tokens
+    token_cache.remove_expired_tokens()
+
+    # Check that the token got deleted from the file
+    failed = False
+    with open(token_cache.cache_location, "r") as f:
+        for line in f.readlines():
+            if token.token_text in line:
+                failed = True
+                break
+    print(token_cache.cache_location)
+    assert not failed
+
+
+def test_token_addition(token_cache, valid_token):
+    token_cache.add_token(valid_token, skip_validation=True)
+    passed = False
+    with open(token_cache.cache_location, "r") as f:
+        for line in f.readlines():
+            if valid_token.token_text in line:
+                passed = True
+                break
+    assert passed
+
+
+def test_token_validity(token_cache, valid_token):
+    assert token_cache.is_valid_token(valid_token, host=dagshub.common.config.host)
+
+
+def test_valid_token_gets_returned(token_cache, valid_token, invalid_token):
+    token_cache.add_token(valid_token, skip_validation=True)
+    token_cache.add_token(invalid_token, skip_validation=True)
+
+    actual = token_cache.get_token()
+    assert actual == valid_token.token_text
+
+
+def test_env_var_tokens_gets_returned_no_matter_what(token_cache, valid_token):
+    token_cache.add_token(valid_token, skip_validation=True)
+
+    old_val = dagshub.common.config.token
+    val = "token-set-in-env-var"
+    try:
+        dagshub.common.config.token = val
+        actual = token_cache.get_token_object()
+
+        assert type(actual) is EnvVarDagshubToken
+        assert actual.token_text == val
+    finally:
+        dagshub.common.config.token = old_val

--- a/tests/dda/test_tokens.py
+++ b/tests/dda/test_tokens.py
@@ -148,3 +148,13 @@ def test_env_var_tokens_gets_returned_no_matter_what(token_cache, valid_token):
         assert actual.token_text == val
     finally:
         dagshub.common.config.token = old_val
+
+
+# The authenticator needs to be picklable in order to work in multiprocess environment
+def test_authenticator_is_picklable(token_cache, valid_token):
+    import pickle
+    token_cache.add_token(valid_token, skip_validation=True)
+    auth = token_cache.get_authenticator()
+    pickled_auth = pickle.dumps(auth)
+    unpickled_auth = pickle.loads(pickled_auth)
+    assert auth.token_text == unpickled_auth.token_text


### PR DESCRIPTION
This PR overhauls the token system:
- Adds an authenticator class that can renegotiate and change tokens in case of failure
- The old `get_token()` function still exists and still gives out the text of the token to keep backwards compat with existing integrations/code
- For everything else it's recommended to switch to `get_authenticator()` that returns an object that can be used with httpx and requests

Caveats: the requests handler doesn't have renegotiations for now, so Data Engine, for example, might still get token failures. There is a TODO and it IS implementable