### PR TITLE
Made savedir a PosixPath object to fix bug

### DIFF
--- a/dagshub/data_engine/client/loaders/base.py
+++ b/dagshub/data_engine/client/loaders/base.py
@@ -40,7 +40,7 @@ class DagsHubDataset:
         )  # prevent circular calls
         self.datasource = query_result.datasource
         self.repo = self.datasource.source.repoApi
-        self.savedir = savedir or self.datasource.default_dataset_location
+        self.savedir = Path(savedir) if savedir else self.datasource.default_dataset_location
         self.strategy = strategy
         self.source = self.datasource.source.path.split("://")[0]
 


### PR DESCRIPTION
When using `savedir` arg in `as_ml_dataloader` it throws an: `TypeError: unsupported operand type(s) for /: 'str' and 'str'` which is a result of using Path operations on a string.

I made it convert the string into a path object in the initialization which should solve the issue.

This was encountered by a customer so we should push this ASAP