### PR TITLE
generate and save permanent token after going through oauth

### DIFF
--- a/dagshub/auth/__init__.py
+++ b/dagshub/auth/__init__.py
@@ -1,4 +1,4 @@
-from .tokens import get_token, add_app_token, add_oauth_token, InvalidTokenError, get_authenticator
+from .tokens import get_token, add_app_token, add_oauth_token, InvalidTokenError, get_authenticator, add_permanent_token
 from .oauth import OauthNonInteractiveShellException
 
 __all__ = [
@@ -8,4 +8,5 @@ __all__ = [
     OauthNonInteractiveShellException.__name__,
     InvalidTokenError.__name__,
     get_authenticator.__name__,
+    add_permanent_token.__name__,
 ]

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DagshubAuthenticator(Auth):
+class token_storage(Auth):
     """
     This class contains a token + flow on how to re-init the token in case of failure
     """

--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class token_storage(Auth):
+class DagshubAuthenticator(Auth):
     """
     This class contains a token + flow on how to re-init the token in case of failure
     """

--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -87,8 +87,9 @@ def setup_dvc(ctx, quiet, repo_name, repo_owner, url, host):
 @click.option("--token", help="Login using a specified token")
 @click.option("--host", help="DagsHub instance to which you want to login")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress print output")
+@click.option("--temporary", is_flag=True, help="Generate only a short lived token, that will expire after 24h")
 @click.pass_context
-def login(ctx, token, host, quiet):
+def login(ctx, token, host, quiet, temporary):
     """
     Initiate an Oauth authentication process. This process will generate and cache a short-lived token in your
     local machine, to allow you to perform actions that require authentication. After running `dagshub login` you can
@@ -102,6 +103,9 @@ def login(ctx, token, host, quiet):
     else:
         dagshub.auth.add_oauth_token(host)
         rich_console.print(":white_check_mark: OAuth token added")
+        if not temporary:
+            dagshub.auth.add_permanent_token(host)
+            rich_console.print(":white_check_mark: Permanent token added")
 
 
 def validate_repo(ctx, param, value):


### PR DESCRIPTION
Provided OAuth token sometimes ends in the middle of training, then starts throwing 401’s. This happens also for users that use local notebooks, where they work intermittently.

### Proposed solution
After oauth token is triggered, set a permanent token for the user using the token API, unless specified otherwise.