### PR TITLE
Change the serialization for OAuth token to make them TZ-naive

### DIFF
--- a/dagshub/auth/token_auth.py
+++ b/dagshub/auth/token_auth.py
@@ -105,7 +105,8 @@ class OAuthDagshubToken(DagshubTokenABC):
     def serialize(self) -> Dict[str, Any]:
         return {
             "access_token": self.token_value,
-            "expiry": self.expiry_date.isoformat(),
+            # ISO format without the timezone info to keep compatible with the older versions
+            "expiry": self.expiry_date.replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "token_type": self.token_type,
         }
 


### PR DESCRIPTION
This is a bug that made the newer client versions not backwards compatible with older client versions.
We were printing out the timezone information when serializing the OAuth tokens, which broke the parsing in old client versions.

Used to be that the token gets serialized: `2023-09-18T18:00:00.123456Z`
Since version 0.3.5: `2023-09-18T18:00:00.123456+00:00Z`
After this PR: `2023-09-18T18:00:00.123456Z`

This PR changes behavior to not print the tz info in the serialized to keep it compatible with the old format.
This change doesn't break current client versions because dateutil.parser by default will deserialize tz-naive into UTC-aware, which is good for 99% of the cases (servers should be giving out UTC-timed tokens anyway)

Test plan:
Scenario 1: saved the token cache with the client on this PR, then checked out client at tag `0.3.4` before the token improvements. Made sure it could open the old tokens
Scenario 2: saved the token cache with the client on this PR, reopened it with the current version, worked