### PR TITLE
Fix problems with blob field filter deserialization

### DIFF
--- a/dagshub/data_engine/model/query.py
+++ b/dagshub/data_engine/model/query.py
@@ -20,8 +20,17 @@ _metadataTypeLookup = {
     bytes: MetadataFieldType.BLOB,
 }
 
+
+def bytes_deserializer(val: str) -> bytes:
+    if val.startswith('b"') or val.startswith("b'"):
+        return val[2:-1].encode()
+    # Fallback - encode whatever we got from the server
+    return val.encode()
+
+
 _metadataTypeCustomConverters = {
     bool: lambda x: x.lower() == "true",
+    bytes: bytes_deserializer,
 }
 
 _metadataTypeLookupReverse: Dict[str, Type] = {}

--- a/dagshub/data_engine/model/query.py
+++ b/dagshub/data_engine/model/query.py
@@ -144,13 +144,18 @@ class DatasourceQuery:
             key = node.data["field"]
             value = node.data["value"]
             value_type = _metadataTypeLookup[type(value)].value
+            if type(value) is bytes:
+                # TODO: this will need to probably be changed when we allow actual binary field comparisons
+                value = value.decode("utf-8")
+            else:
+                value = str(value)
             if value_type is None:
                 raise RuntimeError(f"Value type {value_type} is not supported for querying.\r\n"
                                    f"Supported types: {list(_metadataTypeLookup.keys())}")
             return {
                 "filter": {
                     "key": key,
-                    "value": str(value),
+                    "value": value,
                     "valueType": value_type,
                     "comparator": query_op.value,
                 }

--- a/tests/data_engine/test_querying.py
+++ b/tests/data_engine/test_querying.py
@@ -4,8 +4,9 @@ from dagshub.data_engine.model.datasource import (
     Datasource,
 )
 from dagshub.data_engine.model.errors import WrongOrderError, DatasetFieldComparisonError, FieldNotFoundError
-from dagshub.data_engine.model.query import DatasourceQuery
-from tests.data_engine.util import add_int_fields, add_string_fields, add_float_fields, add_boolean_fields
+from dagshub.data_engine.model.query import DatasourceQuery, bytes_deserializer
+from tests.data_engine.util import add_int_fields, add_string_fields, add_float_fields, add_boolean_fields, \
+    add_blob_fields
 
 
 def test_query_single_column(ds):
@@ -409,3 +410,30 @@ def test_throws_on_nonexistent_field(ds):
     add_int_fields(ds, "col1")
     with pytest.raises(FieldNotFoundError):
         _ = ds["nonexistent_field"] == 5
+
+
+@pytest.mark.parametrize("string_value, expected", [
+    ("b''", bytes()),
+    ('b""', bytes()),
+    ("b'abcd'", "abcd".encode("utf-8")),
+    ("abcd", "abcd".encode("utf-8"))
+])
+def test_bytes_deserializer(string_value, expected):
+    actual = bytes_deserializer(string_value)
+    assert actual == expected
+
+
+def test_blob_deserialization(ds):
+    add_blob_fields(ds, "field_blob")
+    queried = ds["field_blob"].is_null()
+
+    serialized = {
+        "filter": {
+            "key": "field_blob",
+            "value": "b''",
+            "valueType": "BLOB",
+            "comparator": "IS_NULL"
+        }
+    }
+    deserialized = DatasourceQuery.deserialize(serialized)
+    assert queried.get_query().serialize_graphql() == deserialized.serialize_graphql()

--- a/tests/data_engine/test_querying.py
+++ b/tests/data_engine/test_querying.py
@@ -416,7 +416,8 @@ def test_throws_on_nonexistent_field(ds):
     ("b''", bytes()),
     ('b""', bytes()),
     ("b'abcd'", "abcd".encode("utf-8")),
-    ("abcd", "abcd".encode("utf-8"))
+    ("abcd", "abcd".encode("utf-8")),
+    ("", bytes()),
 ])
 def test_bytes_deserializer(string_value, expected):
     actual = bytes_deserializer(string_value)
@@ -430,7 +431,7 @@ def test_blob_deserialization(ds):
     serialized = {
         "filter": {
             "key": "field_blob",
-            "value": "b''",
+            "value": "",
             "valueType": "BLOB",
             "comparator": "IS_NULL"
         }


### PR DESCRIPTION
Before this PR deserializing a query with a blob field filter on it would throw the following error:
```
TypeError: string argument without an encoding
```
Because it was trying to call `bytes("b'<whatever_value_was_there>'")`

This PR fixes this behavior and correctly deserializes the binary values. As a fallback if I don't get the `b'`/`b"`-prefix, I turn the whole value into the byte array

Tests for the custom deserializer + a loop of deserialize->serialize included