### PR TITLE
Move jupyter + fuse into optional dependencies

### DIFF
--- a/dagshub/notebook.py
+++ b/dagshub/notebook.py
@@ -4,24 +4,31 @@ import logging
 import tempfile
 from pathlib import Path, PurePosixPath
 from socket import gethostname, gethostbyname
+from typing import TYPE_CHECKING
 
 import httpx
 import urllib.parse
-from IPython import get_ipython
 
+from dagshub.common.util import lazy_load
 from dagshub.common.helpers import log_message
 from dagshub.upload import Repo
+
+if TYPE_CHECKING:
+    import IPython as IPy
+else:
+    IPy = lazy_load("IPython")
+
 
 logger = logging.getLogger(__name__)
 
 
 def _inside_notebook():
-    return get_ipython() is not None
+    return IPy.get_ipython() is not None
 
 
 def _inside_colab():
     try:
-        if get_ipython() and "google.colab" in get_ipython().extension_manager.loaded:
+        if IPy.get_ipython() and "google.colab" in IPy.get_ipython().extension_manager.loaded:
             return True
     except Exception:
         pass
@@ -89,7 +96,7 @@ def save_notebook(repo, path="", branch=None, commit_message=None, versioning="g
                 file.write(json.dumps(notebook_ipynb["ipynb"], indent=4))
         else:
             log_message("Saving only the execution history for the notebook in Jupyter environments", logger)
-            get_ipython().run_line_magic("notebook", out_path)
+            IPy.get_ipython().run_line_magic("notebook", out_path)
 
         repo = Repo(owner, repo, branch=branch)
         repo.upload(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     "click>=8.0.4",
     "httpx~=0.23.0",
     "GitPython>=3.1.29",
-    "rich[jupyter]~=13.1.0",
+    "rich~=13.1.0",
     # Need to keep dacite version in lockstep with voxel, otherwise stuff breaks on their end
     "dacite~=1.6.0",
     "tenacity~=8.2.2",
@@ -42,6 +42,11 @@ install_requires = [
     "pathvalidate~=3.0.0",
     "python-dateutil",
 ]
+
+extras_require = {
+    "jupyter": ["rich[jupyter]~=13.1.0"],
+    "fuse": ["fusepy>=3"],
+}
 
 # Polyfills for Python 3.7
 if sys.version_info.major == 3 and sys.version_info.minor == 7:


### PR DESCRIPTION
Moved the jupyter fixes for rich + fuse library into their own optional dependencies.
Now installing the jupyter dep is `pip install dagshub[jupyter]`

Tested this branch in Colab, everything kind of works still, but rich's progress bars don't show up until the last second. Doesn't break functionality, but still will probably need to change the notebooks to `pip install dagshub[jupyter]`