### PR TITLE
Bug: setting annotation metadata two times doesn't work

### DIFF
--- a/dagshub/data_engine/client/data_client.py
+++ b/dagshub/data_engine/client/data_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, List, Dict, Union, TYPE_CHECKING
+from typing import Any, Optional, List, Dict, Union, TYPE_CHECKING, Set
 
 import dacite
 import gql
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-dacite_config = dacite.Config(cast=[IntegrationStatus, DatasourceType, PreprocessingStatus, MetadataFieldType])
+dacite_config = dacite.Config(cast=[IntegrationStatus, DatasourceType, PreprocessingStatus, MetadataFieldType, Set])
 
 
 class DataClient:

--- a/dagshub/data_engine/client/models.py
+++ b/dagshub/data_engine/client/models.py
@@ -1,7 +1,7 @@
 import enum
 import logging
 from dataclasses import dataclass, field
-from typing import Any, List, Union, Optional
+from typing import Any, List, Union, Optional, Set
 
 from dataclasses_json import dataclass_json, config
 from dagshub.data_engine.dtypes import MetadataFieldType, ReservedTags
@@ -52,7 +52,7 @@ class MetadataFieldSchema:
     name: str
     valueType: MetadataFieldType = field(metadata=config(encoder=lambda val: val.value))
     multiple: bool
-    tags: Optional[List[str]]
+    tags: Optional[Set[str]]
 
     def __repr__(self):
         res = f"{self.name} ({self.valueType.value})"

--- a/dagshub/data_engine/dtypes.py
+++ b/dagshub/data_engine/dtypes.py
@@ -1,6 +1,6 @@
 import enum
 from abc import ABCMeta
-from typing import List, Set
+from typing import Set
 
 
 class ReservedTags(enum.Enum):

--- a/dagshub/data_engine/dtypes.py
+++ b/dagshub/data_engine/dtypes.py
@@ -1,6 +1,6 @@
 import enum
 from abc import ABCMeta
-from typing import List
+from typing import List, Set
 
 
 class ReservedTags(enum.Enum):
@@ -26,7 +26,7 @@ class DagshubDataType(metaclass=ABCMeta):
     """
 
     backing_field_type: MetadataFieldType = None
-    custom_tags: List[str] = None
+    custom_tags: Set[str] = None
 
 
 class Int(DagshubDataType):
@@ -51,9 +51,9 @@ class Bool(DagshubDataType):
 
 class LabelStudioAnnotation(DagshubDataType):
     backing_field_type = MetadataFieldType.BLOB
-    custom_tags = [ReservedTags.ANNOTATION.value]
+    custom_tags = {ReservedTags.ANNOTATION.value}
 
 
 class Voxel51Annotation(DagshubDataType):
     backing_field_type = MetadataFieldType.BLOB
-    custom_tags = [ReservedTags.ANNOTATION.value]
+    custom_tags = {ReservedTags.ANNOTATION.value}

--- a/dagshub/data_engine/model/metadata_field_builder.py
+++ b/dagshub/data_engine/model/metadata_field_builder.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from typing import TYPE_CHECKING, Type, Union, List, Set
+from typing import TYPE_CHECKING, Type, Union, Set
 
 from dagshub.data_engine.client.models import MetadataFieldSchema
 from dagshub.data_engine.dtypes import DagshubDataType, MetadataFieldType, ReservedTags

--- a/dagshub/data_engine/model/metadata_field_builder.py
+++ b/dagshub/data_engine/model/metadata_field_builder.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from typing import TYPE_CHECKING, Type, Union, List
+from typing import TYPE_CHECKING, Type, Union, List, Set
 
 from dagshub.data_engine.client.models import MetadataFieldSchema
 from dagshub.data_engine.dtypes import DagshubDataType, MetadataFieldType, ReservedTags
@@ -53,7 +53,9 @@ class MetadataFieldBuilder:
         backing_type = self._get_backing_type(t)
 
         if self._schema is None:
-            self._schema = MetadataFieldSchema(name=self._field_name, valueType=backing_type, multiple=False, tags=[])
+            self._schema = MetadataFieldSchema(
+                name=self._field_name, valueType=backing_type, multiple=False, tags=set()
+            )
             if issubclass(t, DagshubDataType) and t.custom_tags is not None:
                 self._schema.tags = t.custom_tags.copy()
         else:
@@ -76,14 +78,15 @@ class MetadataFieldBuilder:
 
     def _set_or_unset(self, tag, is_set):
         if is_set:
-            self._add_tags([tag])
+            self._add_tags({tag})
         else:
             self._remove_tag(tag)
 
-    def _add_tags(self, tags: List[str]):
+    def _add_tags(self, tags: Set[str]):
         if self.schema.tags is None:
-            self.schema.tags = []
-        self.schema.tags.extend(tags)
+            self.schema.tags = set()
+        for t in tags:
+            self.schema.tags.add(t)
 
     def _remove_tag(self, tag: str):
         if self.schema.tags is None:

--- a/tests/data_engine/util.py
+++ b/tests/data_engine/util.py
@@ -33,6 +33,6 @@ def add_boolean_fields(ds: Datasource, *names: str):
 def add_metadata_field(ds: Datasource, name: str, value_type: MetadataFieldType, is_multiple: bool = False,
                        tags: List[str] = None):
     if tags is None:
-        tags = []
+        tags = set()
     field = MetadataFieldSchema(name, value_type, is_multiple, tags)
     ds.source.metadata_fields.append(field)


### PR DESCRIPTION
Reproduction:

```python
ds.metadata_field("annotation").set_annotation().apply()   # Works
ds.metadata_field("annotation").set_annotation().apply()   # Gets GQL error because we're sending double annotation tag
```

Replaced the metadata field tag list with a set