### PR TITLE
Add a GitHub Action to build and upload docs to a GCS Bucket

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -52,3 +52,8 @@ jobs:
           UPLOAD_PATH: ${{ format('gs://{0}/docs/client', secrets.DOCS_BUCKET) }}
         run: gsutil -m rsync -d -r build/html $UPLOAD_PATH
 
+      - name: Invalidate CDN Cache
+        env:
+          LOAD_BALANCER: ${{ secrets.LOAD_BALANCER_NAME }}
+        run: gcloud compute url-maps invalidate-cdn-cache $LOAD_BALANCER --path "/docs/client/*"
+

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,54 @@
+name: Publish Docs
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: "./docs"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install client and dependencies
+        working-directory: "./"
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install .
+      - name: Install docs dependencies
+        run: |
+          pip install -r requirements-docs.txt
+      - name: Build documentation
+        run: make html
+
+#      - name: Upload docs as artifact
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: docs
+#          path: docs/build
+
+      - name: Authenticate with Google
+        uses: "google-github-actions/auth@v2"
+        with:
+          project_id: ${{ secrets.GCS_PROJECT }}
+          credentials_json: ${{ secrets.GCS_SERVICE_ACCOUNT_ACCESS_KEY }}
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Upload to Google Cloud Storage
+        env:
+          UPLOAD_PATH: ${{ format('gs://{0}/docs/client', secrets.DOCS_BUCKET) }}
+        run: gsutil -m rsync -d -r build/html $UPLOAD_PATH
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,11 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
+import sys
+project_root = os.path.join(__file__, "../../..")
+sys.path.insert(0, os.path.abspath(project_root))
+
 project = "DagsHub Client"
 copyright = "2023, DagsHub"
 author = "DagsHub"


### PR DESCRIPTION
Sending required setup procedures to the DMs.

Tested on a separate non-production bucket, made sure that files are only being uploaded to the `docs/client` folder and nothing else is being touched.