### PR TITLE
dagshub upload: variable batch size.

### DIFF
--- a/dagshub/upload/wrapper.py
+++ b/dagshub/upload/wrapper.py
@@ -628,25 +628,28 @@ class DataSet:
                     if "commit_message" in upload_kwargs:
                         del upload_kwargs["commit_message"]
 
-                    file_batchs = []
-                    curr_file_batch = []
-                    curr_batch_file_size = 0
+                    file_batches = []
+                    current_file_batch = []
+                    current_batch_file_size = 0
 
                     for filename in files:
                         rel_file_path = posixpath.join(root, filename)
                         if glob_exclude == "" or fnmatch.fnmatch(rel_file_path, glob_exclude) is False:
-                            curr_file_batch.append(rel_file_path)
-                            curr_batch_file_size += os.path.getsize(rel_file_path)
+                            current_file_batch.append(rel_file_path)
+                            current_batch_file_size += os.path.getsize(rel_file_path)
 
-                            if len(curr_file_batch) >= upload_file_number or curr_batch_file_size >= max_batch_file_size:
-                                file_batchs.append(curr_file_batch)
-                                curr_file_batch = []
-                                curr_batch_file_size = 0
+                            if (
+                                len(current_file_batch) >= upload_file_number
+                                or current_batch_file_size >= max_batch_file_size
+                            ):
+                                file_batches.append(current_file_batch)
+                                current_file_batch = []
+                                current_batch_file_size = 0
 
-                    if curr_file_batch:
-                        file_batchs.append(curr_file_batch)
+                    if current_file_batch:
+                        file_batches.append(current_file_batch)
 
-                    for batch in file_batchs:
+                    for batch in file_batches:
                         for rel_file_path in batch:
                             rel_remote_file_path = rel_file_path.replace(local_path, "")
                             self.add(file=rel_file_path, path=rel_remote_file_path)


### PR DESCRIPTION
1. Uploads are now grouped into the minimum of 100 files or 100MB-s each (not configurable).
2. All uploaded files are discovered before upload begins, to make the global progress bar more useful.
3. Minor restructuring to make the code cleaner.

Notes:

- On my machine (Debian 12), the progress bar is printed many times and not just updated in place. This is annoying, wondering whether you'd like that changed as well.
- In process prints such as "Upload finished successfully!" are confusing and polluting the screen when it's one part of a bigger upload.
- With this change, you may want to change the file batch size from 100 to a larger number, or remove completely.

Resolves #429.