### PR TITLE
Add tenacity + retry on internal server errors in dagshub upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ install_requires = [
     "treelib~=1.6.4",
     "pathvalidate~=3.0.0",
     "python-dateutil",
+    "tenacity~=8.2.3"
 ]
 
 extras_require = {


### PR DESCRIPTION
Long-running `dagshub upload` may hit a server error outside of the control of the user. This adds a retry on that in case there's a server error (and ONLY server error, not any other error type).

Retry is 5 times with a 3s wait between tries.