### PR TITLE
Allow dagshub.init() to be run without any arguments supplied

### DIFF
--- a/dagshub/common/determine_repo.py
+++ b/dagshub/common/determine_repo.py
@@ -1,0 +1,57 @@
+import os
+import urllib.parse
+from pathlib import Path
+from typing import Optional, Union, Tuple
+
+from dagshub.common import config
+from dagshub.common.api import RepoAPI
+from dagshub.common.errors import DagsHubRepoNotFoundError
+
+import git
+
+
+def parse_dagshub_remote(remote_url: urllib.parse.ParseResult, host_url: urllib.parse.ParseResult) -> Optional[str]:
+    if remote_url.hostname != host_url.hostname:
+        return None
+
+    # Check for the host prefix and the path ending with .git
+    if not (remote_url.path.startswith(host_url.path) and remote_url.path.endswith(".git")):
+        return None
+
+    subpath = remote_url.path[len(host_url.path):]
+    # Should leave the subpath of the host, if the remote is correct it should be just "/user/repo.git"
+    subpath = subpath.lstrip("/")
+    if subpath.count("/") > 1:
+        return None
+    return subpath[: -len(".git")]
+
+
+def determine_repo(path: Optional[Union[str, Path]] = None, host: Optional[str] = None) -> Tuple[RepoAPI, str]:
+    """
+    Returns:
+        RepoAPI object of the repo + name of the current branch
+    """
+    if path is None:
+        path = Path.cwd()
+    else:
+        path = Path(path)
+
+    if host is None:
+        host = config.host
+
+    try:
+        repo = git.Repo(path, search_parent_directories=True)
+    except git.InvalidGitRepositoryError as ex:
+        raise DagsHubRepoNotFoundError(path) from ex
+
+    repo_name: Optional[str] = None
+    host_url = urllib.parse.urlparse(host)
+    for remote in repo.remotes:
+        repo_name = parse_dagshub_remote(urllib.parse.urlparse(remote.url), host_url)
+        if repo_name is not None:
+            break
+
+    if repo_name is None:
+        raise DagsHubRepoNotFoundError(path)
+
+    return RepoAPI(repo_name, host=host), repo.active_branch.name

--- a/dagshub/common/errors.py
+++ b/dagshub/common/errors.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+class DagsHubRepoNotFoundError(Exception):
+    def __init__(self, path: Path):
+        super().__init__()
+        self.path = path
+
+    def __str__(self):
+        return (
+            f"Couldn't find a DagsHub repo in the path {self.path} or its parents"
+        )

--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 import urllib
+import urllib.parse
 from os.path import exists
 from pathlib import Path
 from typing import Optional
@@ -10,6 +11,9 @@ import git
 from dagshub.auth import get_token
 from dagshub.auth.token_auth import HTTPBearerAuth
 from dagshub.common import config
+from dagshub.common.api import RepoAPI
+from dagshub.common.api.repo import RepoNotFoundError
+from dagshub.common.determine_repo import parse_dagshub_remote, determine_repo
 from dagshub.common.helpers import get_project_root, http_request, log_message
 from dagshub.upload import create_repo
 
@@ -19,7 +23,7 @@ def init(
     repo_owner: Optional[str] = None,
     url: Optional[str] = None,
     root: Optional[str] = None,
-    host: str = config.host,
+    host: Optional[str] = None,
     mlflow: bool = True,
     dvc: bool = False,
 ):
@@ -43,51 +47,41 @@ def init(
         mlflow: Configure MLflow to log experiments to DagsHub.
         dvc: Configure a dvc remote in the repository.
     """
-    # Setup required variables
-    if dvc:
-        root = root or get_project_root(Path(os.path.abspath(".")))
-        if not exists(root / ".git"):
-            raise ValueError(
-                f"No git project found! (stopped at mountpoint {root}). \
-                               Please run this command in a git repository."
-            )
+    if host is None:
+        host = config.host
 
-    if url and (repo_name or repo_owner):
-        repo_name, repo_owner = None, None
+    if root is None:
+        root = os.path.abspath(".")
 
-    if not url:
-        if repo_name is not None and repo_owner is not None:
-            url = urllib.parse.urljoin(f"{host}/", f"{repo_owner}/{repo_name}")
-        elif dvc:
-            for remote in git.Repo(root).remotes:
-                if host in remote.url:
-                    url = remote.url[:-4]
-    if not url:
-        raise ValueError("No host remote found! Please specify the remote using the url variable, or --url argument.")
-    elif url[-4] == ".":
-        url = url[:-4]
+    # URL specified - ignore repo name and owner args, prioritize url over it
+    # Alternatively, if any of repo owner or name is unset, then unset both of them
+    if url is not None or None in [repo_owner, repo_name]:
+        repo_owner, repo_name = None, None
 
-    if not (repo_name and repo_owner):
-        splitter = lambda x: (x[-1], x[-2])  # noqa E721
-        repo_name, repo_owner = splitter(url.split("/"))
+    # Build URL from repo owner and name
+    if repo_owner and repo_name:
+        url = urllib.parse.urljoin(f"{host}/", f"{repo_owner}/{repo_name}")
+    else:
+        if not url:
+            # Try to get the url of the repo from the git repo
+            repo, branch = determine_repo(root)
+            url = repo.repo_url
 
-    if None in [repo_name, repo_owner, url]:
-        raise ValueError(
-            "Could not parse repository owner and name. Make sure you specify either a link \
-                          to the repository with --url or a pair of --repo-owner and --repo-name"
-        )
+        if url.endswith(".git"):
+            url = url[:-4]
+        # Extract the owner and name from the repo_url
+        parts = url.split("/")
+        repo_owner, repo_name = parts[-2], parts[-1]
 
     # Setup authentication
-    token = config.token or get_token(host=host)
+    token = get_token(host=host)
     bearer = HTTPBearerAuth(token)
 
-    # Configure repository
-    res = http_request(
-        "GET",
-        urllib.parse.urljoin(f"{host}/", config.REPO_INFO_URL.format(owner=repo_owner, reponame=repo_name)),
-        auth=bearer,
-    )
-    if res.status_code == 404:
+    # Create the repo if it wasn't created
+    repo_api = RepoAPI(f"{repo_owner}/{repo_name}", host=host)
+    try:
+        repo_api.get_repo_info()
+    except RepoNotFoundError:
         create_repo(repo_name)
 
     # Configure MLFlow
@@ -96,17 +90,20 @@ def init(
         os.environ["MLFLOW_TRACKING_USERNAME"] = token
         os.environ["MLFLOW_TRACKING_PASSWORD"] = token
 
-        log_message(f"Initialized MLflow to track repo \"{repo_owner}/{repo_name}\"")
+        log_message(f'Initialized MLflow to track repo "{repo_owner}/{repo_name}"')
 
     # Configure DVC
     if dvc:
-        Path(root / ".dvc").mkdir(parents=True, exist_ok=True)
+        git_repo = git.Repo(root, search_parent_directories=True)
+        git_repo_path = Path(git_repo.git_dir)
+
+        Path(git_repo_path / ".dvc").mkdir(parents=True, exist_ok=True)
         write = True
 
         dvc_config = configparser.ConfigParser()
         dvc_config_local = configparser.ConfigParser()
-        dvc_config.read(root / ".dvc" / "config")
-        dvc_config_local.read(root / ".dvc" / "config.local")
+        dvc_config.read(git_repo_path / ".dvc" / "config")
+        dvc_config_local.read(git_repo_path / ".dvc" / "config.local")
 
         for section in dvc_config.sections():
             if "url" in dvc_config[section] and host in dvc_config[section]["url"]:
@@ -117,15 +114,15 @@ def init(
             dvc_config_local[f"'remote \"{remote}\"'"] = {"auth": "basic", "user": token, "password": token}
             dvc_config[f"'remote \"{remote}\"'"] = {"url": f"{url}.dvc"}
 
-            with open(root / ".dvc" / "config", "w") as config_file, open(
-                root / ".dvc" / "config.local", "w"
+            with open(git_repo_path / ".dvc" / "config", "w") as config_file, open(
+                git_repo_path / ".dvc" / "config.local", "w"
             ) as config_local_file:
                 dvc_config.write(config_file)
                 dvc_config_local.write(config_local_file)
                 log_message(f'Added new remote "{remote}" with url = {url}')
 
-        if not exists(root / ".dvc" / ".gitignore"):
-            with open(root / ".dvc" / ".gitignore", "w") as config_gitignore:
+        if not exists(git_repo_path / ".dvc" / ".gitignore"):
+            with open(git_repo_path / ".dvc" / ".gitignore", "w") as config_gitignore:
                 config_gitignore.write(config.CONFIG_GITIGNORE)
 
-    log_message("Repository initialized!")
+    log_message(f"Repository {repo_owner}/{repo_name} initialized!")

--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -55,8 +55,11 @@ def init(
 
     # URL specified - ignore repo name and owner args, prioritize url over it
     # Alternatively, if any of repo owner or name is unset, then unset both of them
-    if url is not None or None in [repo_owner, repo_name]:
+    if url is not None:
         repo_owner, repo_name = None, None
+
+    if None in [repo_owner, repo_name] and (repo_owner is not None or repo_name is not None):
+        raise AttributeError("Both repo_owner and repo_name should be set")
 
     # Build URL from repo owner and name
     if repo_owner and repo_name:
@@ -82,6 +85,7 @@ def init(
     try:
         repo_api.get_repo_info()
     except RepoNotFoundError:
+        log_message(f"Repository {repo_name} doesn't exist, creating it under current user.")
         create_repo(repo_name)
 
     # Configure MLFlow

--- a/tests/common/test_determine_repo.py
+++ b/tests/common/test_determine_repo.py
@@ -124,6 +124,6 @@ def test_cant_find_repo_when_theres_no_repo(tmp_path):
         ("https://token:@dagshub.com/user/repo.git", "https://dagshub.com", "user/repo"),
     ],
 )
-def test_is_dagshub_remote(url, host, expected):
+def test_parse_dagshub_remote(url, host, expected):
     actual = parse_dagshub_remote(urllib.parse.urlparse(url), urllib.parse.urlparse(host))
     assert expected == actual

--- a/tests/common/test_determine_repo.py
+++ b/tests/common/test_determine_repo.py
@@ -1,0 +1,129 @@
+import os
+import urllib.parse
+import uuid
+from typing import Generator, TypeVar
+
+import pytest
+import pytest_git
+
+from dagshub.common.api import RepoAPI
+from dagshub.common.determine_repo import determine_repo, parse_dagshub_remote
+import dagshub.common.config
+from dagshub.common.errors import DagsHubRepoNotFoundError
+from tests.util import remember_cwd
+
+T = TypeVar("T")
+
+YieldFixture = Generator[T, None, None]
+
+
+@pytest.fixture
+def repo_name() -> str:
+    return f"user/repo-{uuid.uuid4()}"
+
+
+@pytest.fixture(
+    params=[
+        "https://dagshub.com",
+        "https://internal.example.com",
+        "https://somewhere.else:8080",
+        "https://somewhere.else:8080/prefix",
+    ]
+)
+def dagshub_host(request) -> YieldFixture[str]:
+    host = request.param
+    old_value = dagshub.common.config.host
+    dagshub.common.config.host = host
+    yield host
+    dagshub.common.config.host = old_value
+
+
+@pytest.fixture(params=[True, False])
+def is_dagshub_origin(request) -> bool:
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def has_auth(request) -> bool:
+    return request.param
+
+
+@pytest.fixture
+def dagshub_repo(
+    git_repo: pytest_git.GitRepo, dagshub_host, is_dagshub_origin, has_auth, repo_name
+) -> pytest_git.GitRepo:
+    parsed_url = urllib.parse.urlparse(dagshub_host)
+    if has_auth:
+        remote_url = f"{parsed_url.scheme}://user:password@{parsed_url.hostname}{parsed_url.path}/{repo_name}.git"
+    else:
+        remote_url = f"{dagshub_host}/{repo_name}.git"
+    other_remote = f"https://other-git-hosting.com/{repo_name}.git"
+
+    repo = git_repo.api
+    if is_dagshub_origin:
+        repo.create_remote("origin", remote_url)
+    else:
+        repo.create_remote("origin", other_remote)
+        repo.create_remote("dagshub", remote_url)
+
+    (git_repo.workspace / "subdir").mkdir()
+    with remember_cwd():
+        os.chdir(git_repo.workspace)
+        yield git_repo
+
+
+@pytest.fixture
+def repo_with_no_dagshub_remote(git_repo, repo_name) -> pytest_git.GitRepo:
+    repo = git_repo.api
+    other_remote = f"https://other-git-hosting.com/{repo_name}.git"
+    repo.create_remote("origin", other_remote)
+
+    with remember_cwd():
+        os.chdir(git_repo.workspace)
+        yield git_repo
+
+
+def test_in_repo_root(dagshub_host, dagshub_repo, repo_name):
+    _test_determine_repo(dagshub_host, dagshub_repo, repo_name)
+
+
+def test_in_folder(dagshub_host, dagshub_repo, repo_name):
+    os.chdir("subdir")
+    _test_determine_repo(dagshub_host, dagshub_repo, repo_name)
+
+
+def _test_determine_repo(dagshub_host: str, dagshub_repo: pytest_git.GitRepo, repo_name: str):
+    res, branch = determine_repo()
+    assert res.full_name == repo_name
+    assert res.host == dagshub_host
+
+
+def test_cant_find_repo(dagshub_host, repo_with_no_dagshub_remote):
+    with pytest.raises(DagsHubRepoNotFoundError):
+        _, _ = determine_repo()
+
+
+def test_cant_find_repo_when_theres_no_repo(tmp_path):
+    with remember_cwd():
+        os.chdir(tmp_path)
+        with pytest.raises(DagsHubRepoNotFoundError):
+            _, _ = determine_repo()
+
+
+@pytest.mark.parametrize(
+    "url, host, expected",
+    [
+        ("https://dagshub.com/user/repo.git", "https://dagshub.com", "user/repo"),
+        ("https://dagshub.com/user/repo", "https://dagshub.com", None),
+        ("https://dagshub.com/random/prefix/user/repo", "https://dagshub.com", None),
+        ("https://dagshub.com/docs", "https://dagshub.com", None),
+        ("https://example.com/user/repo.git", "https://example.com", "user/repo"),
+        ("https://example.com/user/repo.git", "https://dagshub.com", None),
+        ("https://example.com/prefix/user/repo.git", "https://example.com/prefix", "user/repo"),
+        ("https://user:password@dagshub.com/user/repo.git", "https://dagshub.com", "user/repo"),
+        ("https://token:@dagshub.com/user/repo.git", "https://dagshub.com", "user/repo"),
+    ],
+)
+def test_is_dagshub_remote(url, host, expected):
+    actual = parse_dagshub_remote(urllib.parse.urlparse(url), urllib.parse.urlparse(host))
+    assert expected == actual

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,11 @@
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def remember_cwd():
+    curdir = os.getcwd()
+    try:
+        yield
+    finally:
+        os.chdir(curdir)


### PR DESCRIPTION
Right now `dagshub.init()` requires the user to supply the repo owner/name OR its URL.
This PR tries to pick up the repository from the `root` argument (or cwd), if we can find a git repo in the tree.

For this PR I also added a `determine_repo()` function that determines if there's a dagshub repo in the path, and returning a RepoAPI object for it.

Also refactored `dagshub.init()` along the way, making the argument handling more consistent and printing out more information about which repository the user is working with.