### PR TITLE
Bug: Make the client work even when git is not installed

### DIFF
--- a/dagshub/common/determine_repo.py
+++ b/dagshub/common/determine_repo.py
@@ -5,8 +5,9 @@ from typing import Optional, Union, Tuple
 from dagshub.common import config
 from dagshub.common.api import RepoAPI
 from dagshub.common.errors import DagsHubRepoNotFoundError
+from dagshub.common.util import lazy_load
 
-import git
+git = lazy_load("git")
 
 
 def parse_dagshub_remote(remote_url: urllib.parse.ParseResult, host_url: urllib.parse.ParseResult) -> Optional[str]:

--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -6,10 +6,6 @@ from os.path import exists
 from pathlib import Path
 from typing import Optional
 
-
-from dagshub.common.util import lazy_load
-git = lazy_load("git")
-
 from dagshub.auth import get_token
 from dagshub.common import config
 from dagshub.common.api import RepoAPI
@@ -17,6 +13,10 @@ from dagshub.common.api.repo import RepoNotFoundError
 from dagshub.common.determine_repo import determine_repo
 from dagshub.common.helpers import log_message
 from dagshub.upload import create_repo
+
+from dagshub.common.util import lazy_load
+
+git = lazy_load("git")
 
 
 def init(

--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -6,7 +6,9 @@ from os.path import exists
 from pathlib import Path
 from typing import Optional
 
-import git
+
+from dagshub.common.util import lazy_load
+git = lazy_load("git")
 
 from dagshub.auth import get_token
 from dagshub.common import config


### PR DESCRIPTION
Recent pull request made `dagshub.common` import `git` module.
Turns out that importing it errors out, if git is inacessible, so I'm turning that into a lazy loaded module