### PR TITLE
Add ability to visualize in the dagshub gallery view

### DIFF
--- a/dagshub/common/__init__.py
+++ b/dagshub/common/__init__.py
@@ -1,21 +1,5 @@
 import rich.console
-
-
-def is_inside_notebook():
-    try:
-        from IPython import get_ipython
-
-        return get_ipython() is not None
-    except ModuleNotFoundError:
-        return False
-
-
-def is_inside_colab():
-    if not is_inside_notebook():
-        return False
-    from IPython import get_ipython
-
-    return "google.colab" in get_ipython().extension_manager.loaded
+from .notebook import is_inside_colab, is_inside_notebook
 
 
 force_terminal = False if is_inside_notebook() else None

--- a/dagshub/common/__init__.py
+++ b/dagshub/common/__init__.py
@@ -5,3 +5,10 @@ from .notebook import is_inside_colab, is_inside_notebook
 force_terminal = False if is_inside_notebook() else None
 
 rich_console = rich.console.Console(force_terminal=force_terminal)
+
+__all__ = [
+    is_inside_colab.__name__,
+    is_inside_notebook.__name__,
+    "rich_console",
+    "force_terminal",
+]

--- a/dagshub/common/notebook.py
+++ b/dagshub/common/notebook.py
@@ -13,12 +13,3 @@ def is_inside_colab():
     from IPython import get_ipython
 
     return "google.colab" in get_ipython().extension_manager.loaded
-
-
-def open_notebook_iframe(url, **kwargs):
-    if not is_inside_notebook():
-        return
-    from IPython.display import IFrame
-    width = kwargs.pop("width", 800)
-    height = kwargs.pop("height", 400)
-    IFrame(src=url, width=width, height=height, **kwargs)

--- a/dagshub/common/notebook.py
+++ b/dagshub/common/notebook.py
@@ -1,0 +1,24 @@
+def is_inside_notebook():
+    try:
+        from IPython import get_ipython
+
+        return get_ipython() is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def is_inside_colab():
+    if not is_inside_notebook():
+        return False
+    from IPython import get_ipython
+
+    return "google.colab" in get_ipython().extension_manager.loaded
+
+
+def open_notebook_iframe(url, **kwargs):
+    if not is_inside_notebook():
+        return
+    from IPython.display import IFrame
+    width = kwargs.pop("width", 800)
+    height = kwargs.pop("height", 400)
+    IFrame(src=url, width=width, height=height, **kwargs)

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -828,7 +828,7 @@ class Datasource:
             sanitize_filepath(os.path.join(Path.home(), "dagshub", "datasets", self.source.repo, str(self.source.id)))
         )
 
-    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "dagshub", **kwargs) -> Union[str, "fo.Session"]:
+    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "fiftyone", **kwargs) -> Union[str, "fo.Session"]:
         """
         Visualize the whole datasource using
         :func:`QueryResult.visualize() <dagshub.data_engine.model.query_result.QueryResult.visualize>`.

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -21,6 +21,7 @@ import dagshub.common.config
 from dagshub.common import rich_console
 from dagshub.common.analytics import send_analytics_event
 from dagshub.common.helpers import prompt_user, http_request, log_message
+from dagshub.common.notebook import open_notebook_iframe
 from dagshub.common.rich_util import get_rich_progress
 from dagshub.common.util import lazy_load, multi_urljoin, to_timestamp, exclude_if_none
 from dagshub.data_engine.client.models import (
@@ -836,9 +837,16 @@ class Datasource:
         Read the function docs for kwarg documentation.
         """
         if visualizer == "dagshub":
-            url = self._generate_visualize_url()
-            webbrowser.open(url)
-            return url
+            link = self._generate_visualize_url()
+            webbrowser.open(link)
+
+            print("The visualization is available at the following link:")
+            print(link)
+
+            open_notebook_iframe(link)
+
+            return link
+
         elif visualizer == "fiftyone":
             return self.all().visualize(**kwargs)
 

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -838,12 +838,11 @@ class Datasource:
         """
         if visualizer == "dagshub":
             link = self._generate_visualize_url()
-            webbrowser.open(link)
 
             print("The visualization is available at the following link:")
             print(link)
 
-            open_notebook_iframe(link)
+            webbrowser.open(link)
 
             return link
 

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from os import PathLike
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union, Set, ContextManager, Tuple
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union, Set, ContextManager, Tuple, Literal
 
 import rich.progress
 from dataclasses_json import config, LetterCase, DataClassJsonMixin
@@ -828,14 +828,43 @@ class Datasource:
             sanitize_filepath(os.path.join(Path.home(), "dagshub", "datasets", self.source.repo, str(self.source.id)))
         )
 
-    def visualize(self, **kwargs) -> "fo.Session":
+    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "dagshub", **kwargs) -> Union[str, "fo.Session"]:
         """
         Visualize the whole datasource using
         :func:`QueryResult.visualize() <dagshub.data_engine.model.query_result.QueryResult.visualize>`.
 
         Read the function docs for kwarg documentation.
         """
-        return self.all().visualize(**kwargs)
+        if visualizer == "dagshub":
+            url = self._generate_visualize_url()
+            webbrowser.open(url)
+            return url
+        elif visualizer == "fiftyone":
+            return self.all().visualize(**kwargs)
+
+    def _generate_visualize_url(self) -> str:
+        url: str
+        if self.assigned_dataset is not None:
+            url = multi_urljoin(
+                self.source.repoApi.repo_url, f"datasets/dataset/{self.assigned_dataset.dataset_id}/gallery"
+            )
+        else:
+            url = self.source.url
+
+        full_url = url
+        query = self._encode_query_for_frontend()
+        if query is not None:
+            full_url += f"?{query}"
+        return full_url
+
+    def _encode_query_for_frontend(self) -> str:
+        """
+        Returns a query that is parseable by the frontend.
+        It has to be a JSON of the GraphQL query, encoded into b64
+        """
+        params = self._query.to_json()
+        params_encoded = base64.urlsafe_b64encode(params.encode("utf-8")).decode("utf-8")
+        return f"query={params_encoded}"
 
     @property
     def fields(self) -> List[MetadataFieldSchema]:

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -21,7 +21,6 @@ import dagshub.common.config
 from dagshub.common import rich_console
 from dagshub.common.analytics import send_analytics_event
 from dagshub.common.helpers import prompt_user, http_request, log_message
-from dagshub.common.notebook import open_notebook_iframe
 from dagshub.common.rich_util import get_rich_progress
 from dagshub.common.util import lazy_load, multi_urljoin, to_timestamp, exclude_if_none
 from dagshub.data_engine.client.models import (

--- a/dagshub/data_engine/model/datasource_state.py
+++ b/dagshub/data_engine/model/datasource_state.py
@@ -9,6 +9,7 @@ from dagshub.data_engine.client.data_client import DataClient
 from dagshub.data_engine.client.models import DatasourceType, DatasourceResult, PreprocessingStatus, MetadataFieldSchema
 from dagshub.data_engine.model.datapoint import Datapoint
 from dagshub.data_engine.model.errors import DatasourceAlreadyExistsError, DatasourceNotFoundError
+from dagshub.common.util import multi_urljoin
 
 try:
     from functools import cached_property
@@ -62,6 +63,10 @@ class DatasourceState:
             logger.warning("Revision wasn't set, assuming default repo branch")
             self.revision = self.repoApi.default_branch
         return self._revision
+
+    @property
+    def url(self) -> str:
+        return multi_urljoin(self.repoApi.repo_url, f"datasets/datasource/{self.id}/gallery")
 
     @revision.setter
     def revision(self, val: str):

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -485,12 +485,14 @@ class QueryResult:
             logger.warning("Not every datapoint has a size field, size calculations might be wrong")
         return sum_size
 
-    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "dagshub", **kwargs) -> Union[str, "fo.Session"]:
+    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "fiftyone", **kwargs) -> Union[str, "fo.Session"]:
         """
-        Visualize this QueryResult with Voxel51.
+        Visualize this QueryResult either on DagsHub or with Voxel51.
 
-        This function calls :func:`to_voxel51_dataset`, passing to it the keyword arguments,
-        and launches a fiftyone session showing the dataset.
+        If ``visualizer`` is ``dagshub``, a webpage is opened on DagsHub with the query applied.
+
+        If ``visualizer`` is ``fiftyone``, this function calls :func:`to_voxel51_dataset`,
+        passing to it the keyword arguments, and launches a fiftyone session showing the dataset.
 
         Additionally, this function adds a DagsHub plugin into Voxel51 that you can use for additional interactions
         with the datasource from within the voxel environment.


### PR DESCRIPTION
Adds a parameter `visualizer` param to the `visualize` function, that either shows the thing in dagshub or fiftyone. Default is still fiftyone for now to keep backwards compat.
 <BREAKING> once major version is bumped, set the default of the visualize to "dagshub"