### PR TITLE
Data Engine: Add a progress bar for blob downloading

### DIFF
--- a/dagshub/data_engine/model/datapoint.py
+++ b/dagshub/data_engine/model/datapoint.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
-from typing import Tuple, Optional, Union, List, Dict, Any, Callable, TYPE_CHECKING
+from typing import Optional, Union, List, Dict, Any, Callable, TYPE_CHECKING
 
 from dagshub.common.download import download_files
 from dagshub.common.helpers import http_request
@@ -226,12 +226,6 @@ class Datapoint:
 
     def blob_url(self, sha):
         return self.datasource.source.blob_path(sha)
-
-    def _extract_blob_url_and_path(self, col: str) -> Tuple[Optional[str], Optional[PathLike]]:
-        sha = self.metadata.get(col)
-        if sha is None or type(sha) is not str:
-            return None, None
-        return self.blob_url(sha), self.blob_cache_location / sha
 
 
 def _get_blob(

--- a/dagshub/data_engine/model/datapoint.py
+++ b/dagshub/data_engine/model/datapoint.py
@@ -235,7 +235,7 @@ class Datapoint:
 
 
 def _get_blob(
-    url: Optional[str], cache_path: Optional[Path], auth, cache_on_disk, return_blob
+    url: Optional[str], cache_path: Optional[Path], auth, cache_on_disk: bool, return_blob: bool
 ) -> Optional[Union[Path, str, bytes]]:
     """
     Args:

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -1,11 +1,10 @@
 import inspect
 import logging
-import multiprocessing.pool
+from concurrent.futures import as_completed, ThreadPoolExecutor
 from dataclasses import field, dataclass
-from itertools import repeat
 from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Dict, Any, Optional, Union
+from typing import TYPE_CHECKING, List, Dict, Any, Optional, Union, Tuple
 
 import rich.progress
 
@@ -268,31 +267,49 @@ class QueryResult:
 
         # If no fields are specified, include all blob fields from self.datasource.fields
         if not fields:
-            fields = [field.name for field in self.datasource.fields if field.valueType == MetadataFieldType.BLOB]
-
-        for fld in fields:
-            logger.info(f"Downloading metadata for field {fld} with {num_proc} processes")
-            cache_location = self.datasource.default_dataset_location / ".metadata_blobs"
-
-            if cache_on_disk:
-                cache_location.mkdir(parents=True, exist_ok=True)
-
-            blob_urls = list(map(lambda dp: dp._extract_blob_url_and_path(fld), self.entries))
-            auth = self.datasource.source.repoApi.auth
-            func_args = zip(
-                map(lambda bu: bu[0], blob_urls),
-                map(lambda bu: bu[1], blob_urls),
-                repeat(auth),
-                repeat(cache_on_disk),
-                repeat(load_into_memory),
+            fields = tuple(
+                [field.name for field in self.datasource.fields if field.valueType == MetadataFieldType.BLOB]
             )
-            with multiprocessing.pool.ThreadPool(num_proc) as pool:
-                res = pool.starmap(_get_blob, func_args)
 
-            for dp, binary_val_or_path in zip(self.entries, res):
-                if binary_val_or_path is None:
+        if len(fields) == 0:
+            logger.warning("No blob fields loaded")
+            return self
+
+        cache_location = self.datasource.default_dataset_location / ".metadata_blobs"
+
+        if cache_on_disk:
+            cache_location.mkdir(parents=True, exist_ok=True)
+
+        # Create a list of things to download: (datapoint, field, url, path_location)
+        to_download: List[Tuple[Datapoint, str, str, Path]] = []
+        for dp in self.entries:
+            for fld in fields:
+                field_value = dp.metadata.get(fld)
+                # If field_value is a blob or a path, then ignore, means it's already been downloaded
+                if not isinstance(field_value, str):
                     continue
-                dp.metadata[fld] = binary_val_or_path
+                download_task = (dp, fld, dp.blob_url(field_value), dp.blob_cache_location / field_value)
+                to_download.append(download_task)
+
+        progress = get_rich_progress(rich.progress.MofNCompleteColumn(), transient=False)
+        task = progress.add_task("Downloading blobs...", total=len(to_download))
+
+        auth = self.datasource.source.repoApi.auth
+
+        def _get_blob_fn(dp: Datapoint, field: str, url: str, blob_path: Path):
+            blob_or_path = _get_blob(url, blob_path, auth, cache_on_disk, load_into_memory)
+            if isinstance(blob_or_path, str):
+                logger.warning(f"Error while downloading blob for field {field} in datapoint {dp.path}:{blob_or_path}")
+            dp.metadata[field] = blob_or_path
+
+        with progress:
+            with ThreadPoolExecutor(max_workers=num_proc) as tp:
+                futures = [tp.submit(_get_blob_fn, *args) for args in to_download]
+                for f in as_completed(futures):
+                    exc = f.exception()
+                    if exc is not None:
+                        logger.warning(f"Got exception {type(exc)} while downloading blob: {exc}")
+                    progress.update(task, advance=1)
 
         return self
 

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -291,7 +291,7 @@ class QueryResult:
                 download_task = (dp, fld, dp.blob_url(field_value), dp.blob_cache_location / field_value)
                 to_download.append(download_task)
 
-        progress = get_rich_progress(rich.progress.MofNCompleteColumn(), transient=False)
+        progress = get_rich_progress(rich.progress.MofNCompleteColumn())
         task = progress.add_task("Downloading blobs...", total=len(to_download))
 
         auth = self.datasource.source.repoApi.auth


### PR DESCRIPTION
This PR adds a progress bar for downloading blob fields in a query result, similar to the one already used for files downloading.

The number in the progress bar corresponds to the total number of non-None blob fields, so it might be bigger or smaller than number of datapoints.
LMK if you want to change it and show something else instead (n_fields * n_datapoints, or just n_datapoints).

