### PR TITLE
Add a dagshub.colab.login command

### DIFF
--- a/dagshub/auth/oauth.py
+++ b/dagshub/auth/oauth.py
@@ -12,7 +12,7 @@ from dagshub.common import config, rich_console
 logger = logging.getLogger(__name__)
 
 
-def oauth_flow(host: str, client_id: Optional[str] = None) -> OAuthDagshubToken:
+def oauth_flow(host: str, client_id: Optional[str] = None, referrer: Optional[str] = None) -> OAuthDagshubToken:
     """
     Initiate the OAuth 2.0 flow for obtaining an access token.
 
@@ -20,6 +20,7 @@ def oauth_flow(host: str, client_id: Optional[str] = None) -> OAuthDagshubToken:
         host (str): The URL of the OAuth provider.
         client_id (Optional[str], optional): The client ID used for authentication.
             If not provided, it will use the default client ID from the configuration.
+        referrer (Optional[str], optional): For custom referral
 
     Returns:
         Dict: A dictionary containing the obtained access token.
@@ -31,8 +32,10 @@ def oauth_flow(host: str, client_id: Optional[str] = None) -> OAuthDagshubToken:
     state = uuid.uuid4()
     middle_man_request_id = hashlib.sha256(uuid.uuid4().bytes).hexdigest()
     auth_link = (
-        f"{dagshub_url}/authorize?state={state}&client_id={client_id}" f"&middleman_request_id={middle_man_request_id}"
+        f"{dagshub_url}/authorize?state={state}&client_id={client_id}&middleman_request_id={middle_man_request_id}"
     )
+    if referrer is not None:
+        auth_link += f"&referrer={referrer}"
 
     webbrowser.open(auth_link)
 

--- a/dagshub/colab/__init__.py
+++ b/dagshub/colab/__init__.py
@@ -1,0 +1,5 @@
+from .login import login
+
+__all__ = [
+    login.__name__,
+]

--- a/dagshub/colab/login.py
+++ b/dagshub/colab/login.py
@@ -8,10 +8,12 @@ from dagshub.upload import create_repo
 COLAB_REPO_NAME = "dagshub-drive"
 
 
-def login():
+def login() -> str:
     """
-    Run custom colab-specific flow, which helps users with setting up a repository,
-    storage of which will be used as an alternative to Google Drive
+    Run custom colab-specific flow, which helps with setting up a repository,
+    storage of which will be used as an alternative to Google Drive.
+
+    Returns the name of the repository that can be used with colab-related functionality (``<user>/dagshub-drive``)
     """
     try:
         get_token(fail_if_no_token=True)
@@ -28,3 +30,4 @@ def login():
         create_repo(COLAB_REPO_NAME)
     log_message(f"Repository {colab_repo.full_name} is ready for use with Colab. Link to the repository:")
     print(colab_repo.repo_url)
+    return colab_repo.full_name

--- a/dagshub/colab/login.py
+++ b/dagshub/colab/login.py
@@ -2,7 +2,6 @@ from dagshub.auth import add_oauth_token, get_token
 from dagshub.auth.tokens import get_user_of_token
 from dagshub.common.api import RepoAPI
 from dagshub.common.api.repo import RepoNotFoundError
-from dagshub.common.helpers import log_message
 from dagshub.upload import create_repo
 
 COLAB_REPO_NAME = "dagshub-drive"
@@ -28,6 +27,6 @@ def login() -> str:
         colab_repo.get_repo_info()
     except RepoNotFoundError:
         create_repo(COLAB_REPO_NAME)
-    log_message(f"Repository {colab_repo.full_name} is ready for use with Colab. Link to the repository:")
+    print(f"Repository {colab_repo.full_name} is ready for use with Colab. Link to the repository:")
     print(colab_repo.repo_url)
     return colab_repo.full_name

--- a/dagshub/colab/login.py
+++ b/dagshub/colab/login.py
@@ -1,0 +1,30 @@
+from dagshub.auth import add_oauth_token, get_token
+from dagshub.auth.tokens import get_user_of_token
+from dagshub.common.api import RepoAPI
+from dagshub.common.api.repo import RepoNotFoundError
+from dagshub.common.helpers import log_message
+from dagshub.upload import create_repo
+
+COLAB_REPO_NAME = "dagshub-drive"
+
+
+def login():
+    """
+    Run custom colab-specific flow, which helps users with setting up a repository,
+    storage of which will be used as an alternative to Google Drive
+    """
+    try:
+        get_token(fail_if_no_token=True)
+    except RuntimeError:
+        add_oauth_token(referrer="colab")
+
+    token = get_token()
+    username = get_user_of_token(token)
+
+    colab_repo = RepoAPI(f"{username}/{COLAB_REPO_NAME}")
+    try:
+        colab_repo.get_repo_info()
+    except RepoNotFoundError:
+        create_repo(COLAB_REPO_NAME)
+    log_message(f"Repository {colab_repo.full_name} is ready for use with Colab. Link to the repository:")
+    print(colab_repo.repo_url)

--- a/dagshub/colab/login.py
+++ b/dagshub/colab/login.py
@@ -16,11 +16,11 @@ def login() -> str:
     Returns the name of the repository that can be used with colab-related functionality (``<user>/dagshub-drive``)
     """
     try:
-        get_token(fail_if_no_token=True)
+        token = get_token(fail_if_no_token=True)
     except RuntimeError:
         add_oauth_token(referrer="colab")
+        token = get_token()
 
-    token = get_token()
     username = get_user_of_token(token)
 
     colab_repo = RepoAPI(f"{username}/{COLAB_REPO_NAME}")

--- a/docs/source/reference/notebook.rst
+++ b/docs/source/reference/notebook.rst
@@ -4,3 +4,8 @@ Notebook Functions
 .. automodule:: dagshub.notebook
     :members:
 
+Colab specific functions
+--------------------------
+
+.. automodule:: dagshub.colab
+    :members:


### PR DESCRIPTION
This PR adds a `dagshub.colab.login()` command, that leads user through a different auth flow + creates a `<user>/dagshub-drive` repository that will be used for colab-related storage.