### PR TITLE
Infra: drop Python 3.7 polyfills

### DIFF
--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -17,10 +17,7 @@ from dagshub.common.rich_util import get_rich_progress
 from dagshub.common.util import multi_urljoin
 from functools import partial
 
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
+from functools import cached_property
 
 from typing import Optional, Tuple, Any, List, Union
 

--- a/dagshub/common/api/responses.py
+++ b/dagshub/common/api/responses.py
@@ -2,10 +2,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Optional, Dict, List
 
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
+from functools import cached_property
 
 
 @dataclass

--- a/dagshub/common/download.py
+++ b/dagshub/common/download.py
@@ -10,10 +10,7 @@ from httpx import Auth
 
 from dagshub.common import config
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal
 
 import re
 import rich.progress

--- a/dagshub/data_engine/client/data_client.py
+++ b/dagshub/data_engine/client/data_client.py
@@ -28,10 +28,7 @@ from dagshub.data_engine.client.gql_queries import GqlQueries
 from dagshub.data_engine.model.errors import DataEngineGqlError
 from dagshub.data_engine.model.query_result import QueryResult
 
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
+from functools import cached_property
 
 if TYPE_CHECKING:
     from dagshub.data_engine.datasources import DatasourceState

--- a/dagshub/data_engine/model/datasource_state.py
+++ b/dagshub/data_engine/model/datasource_state.py
@@ -11,10 +11,7 @@ from dagshub.data_engine.model.datapoint import Datapoint
 from dagshub.data_engine.model.errors import DatasourceAlreadyExistsError, DatasourceNotFoundError
 from dagshub.common.util import multi_urljoin
 
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
+from functools import cached_property
 
 logger = logging.getLogger(__name__)
 

--- a/dagshub/repo_bucket.py
+++ b/dagshub/repo_bucket.py
@@ -1,7 +1,4 @@
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal
 
 from dagshub.common.api.repo import RepoAPI
 from dagshub.auth import get_token

--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -1,11 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
-
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
+from functools import cached_property
 
 if TYPE_CHECKING:
     from dagshub.streaming import DagsHubFilesystem
@@ -39,7 +35,9 @@ class DagshubPath:
             for storage_schema in storage_schemas:
                 if str_path.startswith(f"{storage_schema}:/"):
                     str_path = str_path[len(storage_schema) + 2 :]
-                    self.relative_path = Path(".dagshub/storage") / storage_schema / str_path
+                    self.relative_path = (
+                        Path(".dagshub/storage") / storage_schema / str_path
+                    )
                     self.absolute_path = self.fs.project_root / self.relative_path
 
     @cached_property

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -31,10 +31,7 @@ PRE_PYTHON3_11 = sys.version_info.major == 3 and sys.version_info.minor < 11
 if PRE_PYTHON3_11:
     from pathlib import _NormalAccessor as _pathlib  # noqa: E402
 
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
+from functools import cached_property
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 import setuptools
 import os.path
 
@@ -49,13 +48,6 @@ extras_require = {
     "jupyter": ["rich[jupyter]~=13.1.0"],
     "fuse": ["fusepy>=3"],
 }
-
-# Polyfills for Python 3.7
-if sys.version_info.major == 3 and sys.version_info.minor == 7:
-    install_requires += [
-        "cached-property==1.5.2",
-        "typing_extensions",
-    ]
 
 packages = setuptools.find_packages(exclude=["tests", "tests.*"])
 


### PR DESCRIPTION
This PR removes following polyfill libraries, that are no longer used, since we dropped Python 3.7 support:
- typing_extensions (for typing.Literal)
- cached-property (for functools.cached_property)