### PR TITLE
Data engine: Add an `as_hf_dataset` to QueryResult

### DIFF
--- a/dagshub/data_engine/model/datapoint.py
+++ b/dagshub/data_engine/model/datapoint.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
-from typing import Optional, Union, List, Dict, Any, Callable, TYPE_CHECKING
+from typing import Optional, Union, List, Dict, Any, Callable, TYPE_CHECKING, Literal
 
 from dagshub.common.download import download_files
 from dagshub.common.helpers import http_request
@@ -229,7 +229,12 @@ class Datapoint:
 
 
 def _get_blob(
-    url: Optional[str], cache_path: Optional[Path], auth, cache_on_disk: bool, return_blob: bool
+    url: Optional[str],
+    cache_path: Optional[Path],
+    auth,
+    cache_on_disk: bool,
+    return_blob: bool,
+    path_format: Literal["str", "path"] = "path",
 ) -> Optional[Union[Path, str, bytes]]:
     """
     Args:
@@ -248,6 +253,8 @@ def _get_blob(
             with cache_path.open("rb") as f:
                 return f.read()
         else:
+            if path_format == "str":
+                cache_path = str(cache_path)
             return cache_path
 
     try:
@@ -266,4 +273,6 @@ def _get_blob(
     if return_blob:
         return content
     else:
+        if path_format == "str":
+            cache_path = str(cache_path)
         return cache_path

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -232,6 +232,15 @@ class QueryResult:
     def as_hf_dataset(self, download_datapoints=True, download_blobs=True):
         """
         Loads this QueryResult as a HuggingFace dataset.
+
+        The paths of the downloads are set to the local paths in the filesystem, so they can be used with
+        a ``cast_column()`` function later.
+
+        Args:
+            download_datapoints: If set to ``True`` (default), downloads the datapoint files and sets the path column\
+                to the path of the datapoint in the filesystem
+            download_blobs: If set to ``True`` (default), downloads all blob fields and sets the respective column\
+                to the path of the file in the filesystem.
         """
         if download_blobs:
             # Download blobs as paths, so later a user can apply ds.cast_column on the blobs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ respx==0.21.1
 pytest-git==1.7.0
 pytest-env==1.1.3
 fiftyone==0.23.7
+datasets==2.18.0


### PR DESCRIPTION
# Spec

This PR adds an `as_hf_dataset` function to the `QueryResult` that allows users to use Data Engine data as a HuggingFace dataset.

Functionality:
- Downloads datapoints and sets the path to the path of the datapoint
- Downloads all blob fields and sets the values to their path
- Gets rid off the autogenerated datapoint_id/dagshub_url fields