### PR TITLE
Data Engine: Autolog to MLflow on datasource queries

### DIFF
--- a/dagshub/common/environment.py
+++ b/dagshub/common/environment.py
@@ -1,0 +1,3 @@
+import importlib.util
+
+is_mlflow_installed = importlib.util.find_spec("mlflow") is not None

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -750,7 +750,8 @@ class Datasource:
         if not is_mlflow_installed:
             return
         # Run ONLY if there's an active run going on
-        if mlflow.active_run() is None:
+        active_run = mlflow.active_run()
+        if active_run is None:
             return
         source_name = self.source.name
 
@@ -758,9 +759,7 @@ class Datasource:
         uuid_chunk = str(uuid.uuid4())[-4:]
 
         artifact_name = f"autolog_{source_name}_{now_time}_{uuid_chunk}.dagshub.json"
-        threading.Thread(
-            target=self.log_to_mlflow, kwargs={"artifact_name": artifact_name, "run": mlflow.active_run()}
-        ).start()
+        threading.Thread(target=self.log_to_mlflow, kwargs={"artifact_name": artifact_name, "run": active_run}).start()
 
     def log_to_mlflow(
         self, artifact_name=DEFAULT_MLFLOW_ARTIFACT_NAME, run: Optional["mlflow.entities.Run"] = None

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -820,6 +820,7 @@ class Datasource:
             query=self._query,
             timestamp=datetime.datetime.now().timestamp(),
             modified=self.is_query_different_from_dataset,
+            link=self._generate_visualize_url(),
         )
         if self.assigned_dataset is not None:
             res.dataset_id = self.assigned_dataset.dataset_id

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -481,7 +481,7 @@ class Datasource:
         :func:`~MetadataContextManager.update_metadata()` function.
         Once the context is exited, all metadata is uploaded in one batch::
 
-            with df.metadata_context() as ctx:
+            with ds.metadata_context() as ctx:
                 ctx.update_metadata("file1", {"key1": True, "key2": "value"})
 
         """


### PR DESCRIPTION
# Implemented in this PR:
- Added a link to open the query in the gallery view
- Added autologging **only on ds.all()** of queries to MLflow
- The logging happens in a parallel thread so as to not interfere with the querying
- Querying works with multiple datasources, correctly saving the query for each ds.
- A new run is created in the last modified experiment per datasource that's being queried, all the queries are then logged into that run.

# Left to implement:
- RIght now the artifacts all get logged with the same name, so they are being overwritten every time. I need to add a tracker for how many logs has been saved.
- Probably would be a good idea to have the autologging togglable in some ways, because the runs created are not being closed and are going to pollute the environment, so I expect advanced users to be able to turn this off.

# Caveats/bugs:
- Closing a run doesn't work if there's a logging session going on to another repo's MLflow. Possible solution - if the current datasource is not in the active run's repo, log in foreground instead of background.