### PR TITLE
Bug: Fix data engine not being able to download files with reserved URL symbols in the file paths 

### DIFF
--- a/dagshub/data_engine/model/datasource_state.py
+++ b/dagshub/data_engine/model/datasource_state.py
@@ -92,15 +92,15 @@ class DatasourceState:
         """
         Returns the url for the content path of a specified path
         """
-        path = self._extract_path(path).strip("/")
-        return self.root_content_path + "/" + path
+        path = self._extract_path(path)
+        return multi_urljoin(self.root_content_path, path)
 
     def raw_path(self, path: Union[str, Datapoint, Mapping[str, Any]]) -> str:
         """
         Returns the url for the download path of a specified path
         """
-        path = self._extract_path(path).strip("/")
-        return self.root_raw_path + "/" + path
+        path = self._extract_path(path)
+        return multi_urljoin(self.root_raw_path, path)
 
     @property
     def source_prefix(self) -> PurePosixPath:

--- a/tests/data_engine/conftest.py
+++ b/tests/data_engine/conftest.py
@@ -5,6 +5,7 @@ from dagshub.data_engine.model.datapoint import Datapoint
 from dagshub.data_engine.model.datasource import Datasource, DatasetState
 from dagshub.data_engine.model.query_result import QueryResult
 from tests.data_engine.util import add_string_fields
+from tests.mocks.repo_api import MockRepoAPI
 
 
 @pytest.fixture
@@ -14,6 +15,7 @@ def ds(mocker) -> Datasource:
     mocker.patch.object(ds_state, "client")
     # Stub out get_from_dagshub, because it doesn't need to be done in tests
     mocker.patch.object(ds_state, "get_from_dagshub")
+    ds_state.repoApi = MockRepoAPI("kirill/repo")
     return Datasource(ds_state)
 
 

--- a/tests/data_engine/test_datapoint.py
+++ b/tests/data_engine/test_datapoint.py
@@ -1,3 +1,14 @@
+from dagshub.data_engine.client.models import DatasourceType
+
+
 def test_getitem_metadata(some_datapoint):
     for key in some_datapoint.metadata:
         assert some_datapoint[key] == some_datapoint.metadata[key]
+
+
+def test_download_url_encoding(some_datapoint):
+    some_datapoint.path = "aaa # bbb/file.txt"
+    some_datapoint.datasource.source.source_type = DatasourceType.REPOSITORY
+    download_url = some_datapoint.download_url
+    assert "#" not in download_url
+    assert download_url.endswith("aaa%20%23%20bbb/file.txt")


### PR DESCRIPTION
Reproduction:

- Create a file structure that includes a `#` symbol somewhere in the path. For example a file at the path `aaa # bbb/file.txt`
- Create a datasource from that structure
- Run:
```python
# get datasource before that
ds.all().download_files()
```

The file with the hash symbol will fail to download.

I added a test that checks that the hash doesn't show up