### PR TITLE
Fix/default visualize

### DIFF
--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -885,7 +885,7 @@ class Datasource:
             sanitize_filepath(os.path.join(Path.home(), "dagshub", "datasets", self.source.repo, str(self.source.id)))
         )
 
-    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "fiftyone", **kwargs) -> Union[str, "fo.Session"]:
+    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "dagshub", **kwargs) -> Union[str, "fo.Session"]:
         """
         Visualize the whole datasource using
         :func:`QueryResult.visualize() <dagshub.data_engine.model.query_result.QueryResult.visualize>`.

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -236,7 +236,9 @@ class QueryResult:
         Loads this QueryResult as a HuggingFace dataset.
 
         The paths of the downloads are set to the local paths in the filesystem, so they can be used with
-        a ``cast_column()`` function later.
+        a `cast_column() \
+        <https://huggingface.co/docs/datasets/main/en/package_reference/main_classes#datasets.Dataset.cast_column>`_\
+        function later.
 
         Args:
             target_dir: Where to download the datapoints. The metadata is still downloaded into the global cache.

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -576,7 +576,7 @@ class QueryResult:
             logger.warning("Not every datapoint has a size field, size calculations might be wrong")
         return sum_size
 
-    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "fiftyone", **kwargs) -> Union[str, "fo.Session"]:
+    def visualize(self, visualizer: Literal["dagshub", "fiftyone"] = "dagshub", **kwargs) -> Union[str, "fo.Session"]:
         """
         Visualize this QueryResult either on DagsHub or with Voxel51.
 


### PR DESCRIPTION
Change the default of the `ds.visualize()` and `qr.visualize()` to visualize to the DagsHub website gallery.

Also added a better explanation of which function is called in the `qr.as_hf_dataset()` function