### PR TITLE
Feature/datetime_metadata_new_timezone

### DIFF
--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -1505,7 +1505,7 @@ def _get_datetime_utc_offset(t):
 class DatasourceQuery(DataClassJsonMixin):
     as_of: Optional[int] = field(default=None, metadata=config(exclude=exclude_if_none, letter_case=LetterCase.CAMEL))
     time_zone: Optional[str] = field(default=None,
-                                    metadata=config(exclude=exclude_if_none, letter_case=LetterCase.CAMEL))
+                                     metadata=config(exclude=exclude_if_none, letter_case=LetterCase.CAMEL))
     select: Optional[List[Dict]] = field(default=None, metadata=config(exclude=exclude_if_none))
     filter: "QueryFilterTree" = field(
         default=QueryFilterTree(),

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -74,6 +74,7 @@ class DatapointMetadataUpdateEntry(DataClassJsonMixin):
     url: str
     key: str
     value: str
+    timeZone: str
     valueType: MetadataFieldType = field(metadata=config(encoder=lambda val: val.value))
     allowMultiple: bool = False
 
@@ -372,7 +373,7 @@ class Datasource:
         """
         new_ds = self.__deepcopy__()
 
-        new_ds._query.timezone = tz_val
+        new_ds._query.time_zone = tz_val
         return new_ds
 
     def order_by(self, *args: Union[str, Tuple[str, Union[bool, str]]]) -> "Datasource":
@@ -1202,10 +1203,6 @@ class Datasource:
 
     def _periodic_filter(self, periodtype, items):
         periods = [str(s) for s in items]
-
-        if not self._query.timezone:
-            self._query.timezone = _get_local_timezone()
-
         return self.add_query_op(periodtype, periods)
 
     def date_field_in_years(self, *item: int):
@@ -1271,7 +1268,6 @@ class Datasource:
 
         """
         self._test_not_comparing_other_ds(item)
-        self._query.timezone = _get_local_timezone()
         return self.add_query_op("timeofday", item)
 
     def startswith(self, item: str):
@@ -1461,11 +1457,13 @@ class MetadataContextManager:
                         if k not in document_fields:
                             continue
 
+                    time_zone = None
                     if isinstance(v, str) and k in document_fields:
                         v = v.encode("utf-8")
                     if isinstance(v, bytes):
                         v = wrap_bytes(v)
                     if isinstance(v, datetime.datetime):
+                        time_zone = _get_datetime_utc_offset(v)
                         v = int(v.timestamp() * 1000)
 
                     self._metadata_entries.append(
@@ -1476,6 +1474,7 @@ class MetadataContextManager:
                             valueType=value_type,
                             # todo: preliminary type check
                             allowMultiple=k in self._multivalue_fields,
+                            timeZone=time_zone,
                         )
                     )
 
@@ -1483,18 +1482,21 @@ class MetadataContextManager:
         return self._metadata_entries
 
 
-def _get_local_timezone():
+def _get_datetime_utc_offset(t):
     """
     return a timezone offset in the form of "+03:00" or "-03:00"
     """
-    # get the offset
-    now = datetime.datetime.now()
-    local_tz = now.astimezone().tzinfo
-    local_offset = local_tz.utcoffset(now)
+
+    if t.tzinfo is None:
+        return None
+
+    offset = t.utcoffset()
+    if offset is None:
+        return None
 
     # Format the offset as a string
-    offset_hours = int(local_offset.total_seconds() // 3600)
-    offset_minutes = int((local_offset.total_seconds() % 3600) // 60)
+    offset_hours = int(offset.total_seconds() // 3600)
+    offset_minutes = int((offset.total_seconds() % 3600) // 60)
     offset_str = f"{offset_hours:+03d}:{offset_minutes:02d}"
     return offset_str
 
@@ -1502,7 +1504,7 @@ def _get_local_timezone():
 @dataclass
 class DatasourceQuery(DataClassJsonMixin):
     as_of: Optional[int] = field(default=None, metadata=config(exclude=exclude_if_none, letter_case=LetterCase.CAMEL))
-    timezone: Optional[str] = field(default=None,
+    time_zone: Optional[str] = field(default=None,
                                     metadata=config(exclude=exclude_if_none, letter_case=LetterCase.CAMEL))
     select: Optional[List[Dict]] = field(default=None, metadata=config(exclude=exclude_if_none))
     filter: "QueryFilterTree" = field(
@@ -1516,7 +1518,7 @@ class DatasourceQuery(DataClassJsonMixin):
     def __deepcopy__(self, memodict={}):
         other = DatasourceQuery(
             as_of=self.as_of,
-            timezone=self.timezone,
+            time_zone=self.time_zone,
             filter=self.filter.__deepcopy__(),
         )
         if self.select is not None:
@@ -1544,8 +1546,8 @@ class DatasourceQuery(DataClassJsonMixin):
                 self.select = other_query.select
             if other_query.as_of is not None:
                 self.as_of = other_query.as_of
-            if other_query.timezone is not None:
-                self.timezone = other_query.timezone
+            if other_query.time_zone is not None:
+                self.time_zone = other_query.time_zone
             if other_query.order_by is not None:
                 self.order_by = other_query.order_by
 

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -74,9 +74,10 @@ class DatapointMetadataUpdateEntry(DataClassJsonMixin):
     url: str
     key: str
     value: str
-    timeZone: str
     valueType: MetadataFieldType = field(metadata=config(encoder=lambda val: val.value))
     allowMultiple: bool = False
+    timeZone: Optional[str] = field(default=None,
+                                    metadata=config(exclude=exclude_if_none, letter_case=LetterCase.CAMEL))
 
 
 @dataclass

--- a/tests/data_engine/test_querying.py
+++ b/tests/data_engine/test_querying.py
@@ -627,7 +627,7 @@ def test_periodic_datetime_periods(ds, period):
     assert q.tree_to_dict() == expected
 
     expected_serialized = {
-        'time_zone': '+03:00',
+        'timeZone': '+03:00',
         'query': {
             'filter': {
                 'key': 'x',
@@ -667,7 +667,7 @@ def test_periodic_datetime_timeofday(ds):
     assert q.tree_to_dict() == expected
 
     expected_serialized = {
-        'time_zone': '+03:00',
+        'timeZone': '+03:00',
         'query': {
             'filter': {
                 'key': 'x',

--- a/tests/data_engine/test_querying.py
+++ b/tests/data_engine/test_querying.py
@@ -627,7 +627,7 @@ def test_periodic_datetime_periods(ds, period):
     assert q.tree_to_dict() == expected
 
     expected_serialized = {
-        'timezone': '+03:00',
+        'time_zone': '+03:00',
         'query': {
             'filter': {
                 'key': 'x',
@@ -667,7 +667,7 @@ def test_periodic_datetime_timeofday(ds):
     assert q.tree_to_dict() == expected
 
     expected_serialized = {
-        'timezone': '+03:00',
+        'time_zone': '+03:00',
         'query': {
             'filter': {
                 'key': 'x',


### PR DESCRIPTION
implement Guys new tz scheme: 
not send local timezone as default. (in most cases user will not want queries according to his own  tz)
send date object timezone in gql updates. so that BE will save it and use in queries

TODO documentation