### PR TITLE
Add retry to the download function

### DIFF
--- a/dagshub/common/download.py
+++ b/dagshub/common/download.py
@@ -130,7 +130,7 @@ def download_url_to_bucket_path(url: str) -> Optional[Tuple[str, str, str]]:
 class DownloadError(Exception):
     def __init__(self, response: Response):
         self.response = response
-        super().__init__("Download failed with status code {response.status_code}")
+        super().__init__(f"Download failed with status code {response.status_code}")
 
 
 def is_download_server_error(error: BaseException) -> bool:


### PR DESCRIPTION
This PR adds retries on 5xx codes to the `download_files()` function.

This should mitigate problems occurring because of the server rate-limiting access to the /raw/ endpoint.

Example usecase that would cause the download to hit the rate limit:

```python
repo = RepoAPI("simon/baby-yoda-segmentation-dataset")
repo.download("images")
```

Before this PR user ends up with an incomplete directory. After this, it should eventually be downloaded (I have set the retries to max 5, so a long enough downtime would still fail)