### PR TITLE
Bug: Filter the metadata fields based on the introspection

### DIFF
--- a/dagshub/data_engine/client/gql_queries.py
+++ b/dagshub/data_engine/client/gql_queries.py
@@ -42,7 +42,12 @@ class GqlQueries:
     @staticmethod
     @functools.lru_cache()
     def datasource_query(include_metadata: bool, introspection: "TypesIntrospection") -> GqlQuery:
-        metadata_fields = "metadata { key value timeZone }" if include_metadata else ""
+        metadata_fields = ""
+        if include_metadata:
+            # Filter out the unavailable fields
+            queryable_fields = ["key", "value", "timeZone"]
+            queryable_fields = Validators.filter_supported_fields(queryable_fields, "MetadataField", introspection)
+            metadata_fields = "metadata " + "{" + " ".join(queryable_fields) + "}"
         q = (
             GqlQuery()
             .operation(


### PR DESCRIPTION
New timeZone field is not yet deployed in production, and because of that the queries are failing on the current version of the client.

I added introspection-based filtering that removes the timeZone field if it's not included in the GQL schema.
This is not a big deal for the consuming code, because the consuming code uses `metadata.get("timeZone")` later to get the time zone, falling back to +00:00, so should be ok.