### PR TITLE
Tests: Pin path lib to 16.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ pytest-env==1.1.3
 pytest-mock==3.14.0
 fiftyone==0.23.8
 datasets==2.19.1
+# TODO: REMOVE AFTER pytest-shutil has been fixed: https://github.com/man-group/pytest-plugins/issues/224
+path==16.0.0


### PR DESCRIPTION
This fixes the bug where `pytest-shutil` fails doing the teardown, because the function they are using got removed in `path==17.0.0`

I've referenced an issue for that in the PR, this should be removed after that issue is closed