### PR TITLE
Handle datetimes correctly for dataframe + multivalue

### DIFF
--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -598,6 +598,9 @@ class Datasource:
                             sub_val = sub_val.encode("utf-8")
                         if isinstance(sub_val, bytes):
                             sub_val = wrap_bytes(sub_val)
+                        if isinstance(sub_val, datetime.datetime):
+                            time_zone = _get_datetime_utc_offset(sub_val)
+                            sub_val = int(sub_val.timestamp() * 1000)
                         res.append(
                             DatapointMetadataUpdateEntry(
                                 url=datapoint, key=key, value=str(sub_val), valueType=value_type, allowMultiple=True
@@ -619,6 +622,9 @@ class Datasource:
                         val = val.encode("utf-8")
                     if isinstance(val, bytes):
                         val = wrap_bytes(val)
+                    if isinstance(val, datetime.datetime):
+                        time_zone = _get_datetime_utc_offset(val)
+                        val = int(val.timestamp() * 1000)
                     res.append(
                         DatapointMetadataUpdateEntry(
                             url=datapoint,
@@ -1449,6 +1455,9 @@ class MetadataContextManager:
                                 continue
                         if isinstance(v, str) and k in document_fields:
                             v = v.encode("utf-8")
+                        if isinstance(v, datetime.datetime):
+                            time_zone = _get_datetime_utc_offset(v)
+                            v = int(v.timestamp() * 1000)
                         if isinstance(v, bytes):
                             sub_val = wrap_bytes(sub_val)
                         self._metadata_entries.append(

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -584,6 +584,7 @@ class Datasource:
                                 update_entry.allowMultiple = True
                     for sub_val in val:
                         value_type = field_value_types.get(key)
+                        time_zone = None
                         if value_type is None:
                             value_type = metadataTypeLookup[type(sub_val)]
                             field_value_types[key] = value_type
@@ -603,7 +604,12 @@ class Datasource:
                             sub_val = int(sub_val.timestamp() * 1000)
                         res.append(
                             DatapointMetadataUpdateEntry(
-                                url=datapoint, key=key, value=str(sub_val), valueType=value_type, allowMultiple=True
+                                url=datapoint,
+                                key=key,
+                                value=str(sub_val),
+                                valueType=value_type,
+                                allowMultiple=True,
+                                timeZone=time_zone,
                             )
                         )
                 else:
@@ -615,6 +621,7 @@ class Datasource:
                     if value_type == MetadataFieldType.BLOB and not isinstance(val, bytes):
                         if key not in document_fields:
                             continue
+                    time_zone = None
                     # Pandas quirk - integers are floats on the backend
                     if value_type == MetadataFieldType.INTEGER:
                         val = int(val)
@@ -632,6 +639,7 @@ class Datasource:
                             value=str(val),
                             valueType=value_type,
                             allowMultiple=key in multivalue_fields,
+                            timeZone=time_zone,
                         )
                     )
         return res
@@ -1444,6 +1452,7 @@ class MetadataContextManager:
                             if e.key == k:
                                 e.allowMultiple = True
                     for sub_val in v:
+                        time_zone = None
                         value_type = field_value_types.get(k)
                         if value_type is None:
                             value_type = metadataTypeLookup[type(sub_val)]
@@ -1468,6 +1477,7 @@ class MetadataContextManager:
                                 # todo: preliminary type check
                                 valueType=value_type,
                                 allowMultiple=k in self._multivalue_fields,
+                                timeZone=time_zone,
                             )
                         )
 

--- a/tests/data_engine/test_datasource.py
+++ b/tests/data_engine/test_datasource.py
@@ -149,8 +149,12 @@ def test_pandas_timestamp(ds):
     actual = Datasource._df_to_metadata(ds, df)
 
     expected = [
-        DatapointMetadataUpdateEntry("test1", "key1", "2020-10-10 10:10:00", MetadataFieldType.DATETIME),
-        DatapointMetadataUpdateEntry("test2", "key1", "2030-10-10 10:20:20", MetadataFieldType.DATETIME),
+        DatapointMetadataUpdateEntry(
+            "test1", "key1", f"{int(data_dict['key1'][0].timestamp()) * 1000}", MetadataFieldType.DATETIME
+        ),
+        DatapointMetadataUpdateEntry(
+            "test2", "key1", f"{int(data_dict['key1'][1].timestamp()) * 1000}", MetadataFieldType.DATETIME
+        ),
     ]
 
     assert expected == actual


### PR DESCRIPTION
The backend expects datetimes to be sent as timestamp + additionally a timeZone field in the metadata, if there's a timezone.

The dataframe code wasn't handling that right.
This bug fixes it.

Made sure to test an upload locally from a dataframe, to be sure that it's working e2e now. Got the same data I uploaded back