### PR TITLE
Added a generalized tensorizer definition

### DIFF
--- a/dagshub/data_engine/client/loaders/base.py
+++ b/dagshub/data_engine/client/loaders/base.py
@@ -17,7 +17,7 @@ class DagsHubDataset:
         metadata_columns: List[str] = [],
         file_columns: List[str] = None,
         strategy: str = "lazy",
-        tensorizers: Union[str, List[Union[str, FunctionType]]] = "auto",
+        tensorizers: Union[str, List[Union[str, FunctionType]], FunctionType] = "auto",
         savedir: str = None,
         processes: int = 8,
         for_dataloader: bool = False,
@@ -31,7 +31,7 @@ class DagsHubDataset:
             columns that are returned from the metadata as part of the dataloader.Defaults to [].
         file_columns (List[str], optional): columns with a datapoint metadata that are files. Defaults to None.
         strategy (str, optional): Download strategy - preload|background|lazy. Defaults to "lazy".
-        tensorizers (Union[str, List[Union[str, FunctionType]]], optional):
+        tensorizers (Union[str, List[Union[str, FunctionType]], FunctionType], optional):
             Tensorization strategy - auto|image|<function>. Defaults to "auto".
         savedir (str, optional): Location where the dataset is stored. Defaults to None.
         processes (int, optional): number of parallel processes that download the dataset. Defaults to 8.

--- a/dagshub/data_engine/client/loaders/base.py
+++ b/dagshub/data_engine/client/loaders/base.py
@@ -58,7 +58,7 @@ class DagsHubDataset:
 
         self.tensorizers = (
             self._get_tensorizers(tensorizers)
-            if type(tensorizers) is str or type(tensorizers[0]) is str
+            if type(tensorizers) is str or (type(tensorizers) is list and type(tensorizers[0]) is str)
             else tensorizers
         )
 
@@ -124,7 +124,10 @@ class DagsHubDataset:
         return out
 
     def __getitem__(self, idx: int) -> List[Union["torch.Tensor", "tf.Tensor"]]:  # noqa: F821
-        return [tensorizer(data) for tensorizer, data in zip(self.tensorizers, self.get(idx))]
+        if type(self.tensorizers) is list:
+            return [tensorizer(data) for tensorizer, data in zip(self.tensorizers, self.get(idx))]
+        else:
+            return self.tensorizers(self.get(idx))
 
     def pull(self) -> None:
         if self.order is not None:


### PR DESCRIPTION
Currently, the process for creating tensors from datapoints on the Data Engine requires specifying a tensorizer function for each field.

This PR adds a unified definition, where you are supplied a list of fields and can create the tensor definitions flexibile enough to meet any user specification.