### PR TITLE
enhancement / remote metadata upload 

### DIFF
--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -1,7 +1,6 @@
 import logging
 from os import PathLike
 from pathlib import Path, PurePosixPath
-import mimetypes
 import rich.progress
 
 from dagshub.common.api.responses import (
@@ -388,30 +387,6 @@ class RepoAPI:
         download_files(file_tuples, skip_if_exists=not redownload)
         log_message(f"Downloaded {len(files)} file(s) to {local_path.resolve()}")
 
-    def import_metadata_from_file(self, datasource_name: str, file_path: Union[str, PathLike], path_column: str):
-        files = {
-            "file": (
-                Path(file_path).name,
-                open(file_path, "rb"),
-                mimetypes.guess_type(file_path)[0] or "application/octet-stream",
-            ),
-        }
-
-        data = {
-            "datasource_name": datasource_name,
-            "path_column": path_column,
-        }
-
-        res = self._http_request("POST", self.repo_import_metadata_from_file_url(), data=data, files=files)
-        if res.status_code == 404:
-            raise PathNotFoundError(f"Datasource {datasource_name} not found")
-        elif res.status_code >= 400:
-            error_msg = f"Got status code {res.status_code} when importing metadata to datasource {datasource_name}"
-            logger.error(error_msg)
-            logger.debug(res.content)
-            raise RuntimeError(error_msg)
-        return res.content
-
     @staticmethod
     def _sanitize_storage_path(path: Union[str, PathLike]) -> Tuple[str, bool]:
         """
@@ -586,9 +561,6 @@ class RepoAPI:
         :meta private:
         """
         return multi_urljoin(self.host, "api/v1/repo-buckets/s3", self.owner)
-
-    def repo_import_metadata_from_file_url(self) -> str:
-        return multi_urljoin(self.data_engine_url, "import/metadata")
 
     @staticmethod
     def parse_repo(repo: str) -> Tuple[str, str]:

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -532,7 +532,7 @@ class Datasource:
 
         if ingest_on_server:
             datasource_name = self.source.name
-            self.source.repoApi.import_metadata_from_file(datasource_name, file_path, path_column)
+            self._source.import_metadata_from_file(datasource_name, file_path, path_column)
         else:
             df = self._convert_file_to_df(file_path)
             self.upload_metadata_from_dataframe(df, path_column, ingest_on_server)
@@ -572,7 +572,7 @@ class Datasource:
             file_path = tmp.name
             df.to_parquet(file_path, index=False)
 
-            self.source.repoApi.import_metadata_from_file(datasource_name, file_path, path_column)
+            self._source.import_metadata_from_file(datasource_name, file_path, path_column)
 
     def _get_multivalue_fields(self) -> Set[str]:
         res = set()

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -1450,7 +1450,9 @@ class Datasource:
         elif file_path.lower().endswith(".gz"):
             df = pd.read_csv(file_path, compression="gzip")
         else:
-            raise RuntimeError(f"Unsupported file format: {file_path}")
+            raise RuntimeError(
+                f"File '{file_path}' needs to be a .csv/.parquet or a compressed .zip/.gz to be imported"
+            )
         return df
 
 

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -530,11 +530,8 @@ class Datasource:
         send_analytics_event("Client_DataEngine_addEnrichmentsWithFile", repo=self.source.repoApi)
 
         if remote:
-            try:
-                datasource_name = self.source.name
-                self.source.repoApi.import_metadata_from_file(datasource_name, file_path, path_column)
-            except:  # noqa # todo better exception handling when we'll have feedback from the backend
-                pass
+            datasource_name = self.source.name
+            self.source.repoApi.import_metadata_from_file(datasource_name, file_path, path_column)
         else:
             df = self._convert_file_to_df(file_path)
             self.upload_metadata_from_dataframe(df, path_column, remote)

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -15,7 +15,6 @@ from os import PathLike
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union, Set, ContextManager, Tuple, Literal
 
-import pandas as pd
 import rich.progress
 from dataclasses_json import config, LetterCase, DataClassJsonMixin
 from pathvalidate import sanitize_filepath
@@ -1440,13 +1439,13 @@ class Datasource:
     def _convert_file_to_df(file_path: str):
         # prepare dataframe for import_metadata
         if file_path.lower().endswith(".csv"):
-            df = pd.read_csv(file_path)
+            df = pandas.read_csv(file_path)
         elif file_path.lower().endswith(".parquet"):
-            df = pd.read_parquet(file_path)
+            df = pandas.read_parquet(file_path)
         elif file_path.lower().endswith(".zip"):
-            df = pd.read_csv(file_path, compression="zip")
+            df = pandas.read_csv(file_path, compression="zip")
         elif file_path.lower().endswith(".gz"):
-            df = pd.read_csv(file_path, compression="gzip")
+            df = pandas.read_csv(file_path, compression="gzip")
         else:
             raise RuntimeError(
                 f"File '{file_path}' needs to be a .csv/.parquet or a compressed .zip/.gz to be imported"

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -526,7 +526,6 @@ class Datasource:
                 Remote upload means that the data engine API calls will be done from remote machine,
                 rather than from local machine which runs this client.
         """
-        self.source.get_from_dagshub()
         send_analytics_event("Client_DataEngine_addEnrichmentsWithFile", repo=self.source.repoApi)
 
         if remote:


### PR DESCRIPTION
Main changes:
1. extend existing `upload_metadata_from_dataframe` to include `remote` flag
2. new method `upload_metadata_from_file` which will allow uploading metadata from a file + include `remote` flag
3. when remote is false - fallback to existing behavior
4. when remote is true - call our backend with `import/metadata` endpoint which will use python bgproc that also using the client with but with remote = false (meaning that dataengine api calls will be done in remote environment)