### PR TITLE
Add a fallback on annotation validation

### DIFF
--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from collections import Counter
+from collections import Counter, defaultdict
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from dataclasses import field, dataclass
 from os import PathLike
@@ -15,6 +15,7 @@ from dagshub_annotation_converter.formats.yolo import YoloContext
 from dagshub_annotation_converter.formats.yolo.categories import Categories
 from dagshub_annotation_converter.formats.yolo.common import ir_mapping
 from dagshub_annotation_converter.ir.image import IRImageAnnotationBase
+from pydantic import ValidationError
 
 from dagshub.common import config
 from dagshub.common.analytics import send_analytics_event
@@ -395,21 +396,7 @@ class QueryResult:
                         logger.warning(f"Got exception {type(exc)} while downloading blob: {exc}")
                     progress.update(task, advance=1)
 
-        # Convert any downloaded annotation column
-        annotation_fields = [f for f in fields if f in self.annotation_fields]
-        if annotation_fields:
-            # Convert them
-            for dp in self:
-                for fld in annotation_fields:
-                    if fld in dp.metadata:
-                        # Override the load_into_memory flag, because we need the contents
-                        if not load_into_memory:
-                            dp.metadata[fld] = Path(dp.metadata[fld]).read_bytes()
-                        dp.metadata[fld] = MetadataAnnotations.from_ls_task(
-                            datapoint=dp, field=fld, ls_task=dp.metadata[fld]
-                        )
-                    else:
-                        dp.metadata[fld] = MetadataAnnotations(datapoint=dp, field=fld)
+        self._convert_annotation_fields(*fields, load_into_memory=load_into_memory)
 
         # Convert any downloaded document fields
         document_fields = [f for f in fields if f in self.document_fields]
@@ -423,6 +410,38 @@ class QueryResult:
                         dp.metadata[fld] = dp.metadata[fld].decode("utf-8")
 
         return self
+
+    def _convert_annotation_fields(self, *fields, load_into_memory):
+        # Convert any downloaded annotation column
+        annotation_fields = [f for f in fields if f in self.annotation_fields]
+
+        bad_annotations = defaultdict(list)
+
+        if annotation_fields:
+            # Convert them
+            for dp in self:
+                for fld in annotation_fields:
+                    if fld in dp.metadata:
+                        # Override the load_into_memory flag, because we need the contents
+                        if not load_into_memory:
+                            dp.metadata[fld] = Path(dp.metadata[fld]).read_bytes()
+                        try:
+                            dp.metadata[fld] = MetadataAnnotations.from_ls_task(
+                                datapoint=dp, field=fld, ls_task=dp.metadata[fld]
+                            )
+                        except ValidationError:
+                            bad_annotations[fld].append(dp.path)
+                    else:
+                        dp.metadata[fld] = MetadataAnnotations(datapoint=dp, field=fld)
+
+        log_message("Warning: The following datapoints had invalid annotations, "
+                    "any annotation-related operations will not work on these:")
+        err_msg = ""
+        for fld, dps in bad_annotations.items():
+            err_msg += f'Field "{fld}" in datapoints:\n\t'
+            err_msg += "\n\t".join(dps)
+        log_message(err_msg)
+
 
     def download_binary_columns(
         self,

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -434,14 +434,15 @@ class QueryResult:
                     else:
                         dp.metadata[fld] = MetadataAnnotations(datapoint=dp, field=fld)
 
-        log_message("Warning: The following datapoints had invalid annotations, "
-                    "any annotation-related operations will not work on these:")
+        log_message(
+            "Warning: The following datapoints had invalid annotations, "
+            "any annotation-related operations will not work on these:"
+        )
         err_msg = ""
         for fld, dps in bad_annotations.items():
             err_msg += f'Field "{fld}" in datapoints:\n\t'
             err_msg += "\n\t".join(dps)
         log_message(err_msg)
-
 
     def download_binary_columns(
         self,


### PR DESCRIPTION
Having a malformed annotation on a datapoint (or an annotation that failed to parse, not even malformed) right now leads to the whole loading process failing.

This PR is a hotfix to prevent that.
If an annotation fails to parse, it gets shown to the user in a warning message, and I warn them that they won't be able to interact with them, for example:

```
Accessing as kirill
Downloading annotation fields ['annotation']...
Warning: The following datapoints had invalid annotations, any annotation-related operations will not work on these:
Field "annotation" in datapoints:
        train2017/000000000009.jpg
```

I'm not handling these bad annotations in other downstream functions for now properly, if we do want to make it have a nice UX, would probably need to have some kind of `BrokenAnnotation` class that will shim the regular annotation functions and display a warning.
Not sure if it's worth it to work on this right now