### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points={"console_scripts": ["dagshub = dagshub.common.cli:cli"]},
 )


### PR DESCRIPTION
3.7 has been EOL since 2023, we should drop it
Besides, the annotation converter also wasn't tested with 3.7 at all, so I can't guarantee that it will work on 3.7 anyway.