### PR TITLE
Fix but in 'LS backend with MLflow model' flow

### DIFF
--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -57,10 +57,7 @@ from dagshub.data_engine.model.metadata_field_builder import MetadataFieldBuilde
 from dagshub.data_engine.model.query import QueryFilterTree
 from dagshub.data_engine.model.schema_util import metadataTypeLookup, metadataTypeLookupReverse
 from dagshub.data_engine.model.datasource_state import DatasourceState
-# 👇 Required for running adding of LS backend from a notebook
-import asyncio
-import nest_asyncio
-nest_asyncio.apply()
+
 if TYPE_CHECKING:
     from dagshub.data_engine.model.query_result import QueryResult
     import fiftyone as fo
@@ -1039,7 +1036,7 @@ class Datasource:
         return self.source.metadata_fields
 
     @retry(retry=retry_if_exception_type(LSInitializingError), wait=wait_fixed(3), stop=stop_after_attempt(5))
-    def add_annotation_model_from_config(self, config, project_name, ngrok_authtoken, port=9090):
+    async def add_annotation_model_from_config(self, config, project_name, ngrok_authtoken, port=9090):
         """
         Initialize a LS backend for ML annotation using a preset configuration.
 
@@ -1079,10 +1076,10 @@ class Datasource:
             if res.status_code // 100 != 2:
                 raise ValueError(f"Adding backend failed! Response: {res.text}")
 
-        self.add_annotation_model(**config, port=port, project_name=project_name, ngrok_authtoken=ngrok_authtoken)
+        await self.add_annotation_model(**config, port=port, project_name=project_name, ngrok_authtoken=ngrok_authtoken)
 
     @retry(retry=retry_if_exception_type(LSInitializingError), wait=wait_fixed(3), stop=stop_after_attempt(5))
-    def add_annotation_model(
+    async def add_annotation_model(
         self,
         repo: str,
         name: str,
@@ -1139,7 +1136,7 @@ class Datasource:
 
             if ngrok_authtoken:
                 if not self.ngrok_listener:
-                    self.ngrok_listener = asyncio.run(ngrok.forward(port, authtoken=ngrok_authtoken))
+                    self.ngrok_listener = await ngrok.forward(port, authtoken=ngrok_authtoken)
                 endpoint = self.ngrok_listener.url()
             else:
                 endpoint = f"{LS_ORCHESTRATOR_URL}:{port}/"

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -57,7 +57,10 @@ from dagshub.data_engine.model.metadata_field_builder import MetadataFieldBuilde
 from dagshub.data_engine.model.query import QueryFilterTree
 from dagshub.data_engine.model.schema_util import metadataTypeLookup, metadataTypeLookupReverse
 from dagshub.data_engine.model.datasource_state import DatasourceState
-
+# 👇 Required for running adding of LS backend from a notebook
+import asyncio
+import nest_asyncio
+nest_asyncio.apply()
 if TYPE_CHECKING:
     from dagshub.data_engine.model.query_result import QueryResult
     import fiftyone as fo
@@ -1136,7 +1139,7 @@ class Datasource:
 
             if ngrok_authtoken:
                 if not self.ngrok_listener:
-                    self.ngrok_listener = ngrok.forward(port, authtoken=ngrok_authtoken)
+                    self.ngrok_listener = asyncio.run(ngrok.forward(port, authtoken=ngrok_authtoken))
                 endpoint = self.ngrok_listener.url()
             else:
                 endpoint = f"{LS_ORCHESTRATOR_URL}:{port}/"


### PR DESCRIPTION
I tried running and got:
```
File /usr/local/lib/python3.11/site-packages/tenacity/__init__.py:382, in Retrying.__call__(self, fn, *args, **kwargs)
    380 if isinstance(do, DoAttempt):
    381     try:
--> 382         result = fn(*args, **kwargs)
    383     except BaseException:  # noqa: B902
    384         retry_state.set_exception(sys.exc_info())  # type: ignore[arg-type]

File /usr/local/lib/python3.11/site-packages/dagshub/data_engine/model/datasource.py:1140, in Datasource.add_annotation_model(self, repo, name, version, post_hook, pre_hook, port, project_name, ngrok_authtoken)
   1138     if not self.ngrok_listener:
   1139         self.ngrok_listener = ngrok.forward(port, authtoken=ngrok_authtoken)
-> 1140     endpoint = self.ngrok_listener.url()
   1141 else:
   1142     endpoint = f"{LS_ORCHESTRATOR_URL}:{port}/"

AttributeError: '_asyncio.Task' object has no attribute 'url'
```

This PR solves this issue without changing any interface.
