### PR TITLE
Infra: Bump pytest-git to 1.8.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,9 @@
 setuptools==70.0.0
 pytest==8.2.1
 respx==0.21.1
-pytest-git==1.7.0
+pytest-git==1.8.0
 pytest-env==1.1.3
 pytest-mock==3.14.0
 fiftyone==0.23.8
 datasets==2.19.1
 ultralytics==8.2.48
-# TODO: REMOVE AFTER pytest-shutil has been fixed: https://github.com/man-group/pytest-plugins/issues/224
-path==16.0.0


### PR DESCRIPTION
This version fixed the dependency on the old version of the path library, so we can finally drop it hopefully