### PR TITLE
Enhancement: Override config.host in dagshub.init

### DIFF
--- a/dagshub/common/config.py
+++ b/dagshub/common/config.py
@@ -61,3 +61,12 @@ if download_threads > DEFAULT_DOWNLOAD_THREADS:
         f"Number of download threads was set to {download_threads}. "
         f"We recommend lowering the value if you get met with rate limits"
     )
+
+
+def set_host(new_host: str):
+    _parsed_host = urlparse(new_host)
+    _hostname = _parsed_host.hostname
+    _host = _parsed_host.geturl().rstrip("/")
+
+    global hostname, host, parsed_host
+    hostname, host, parsed_host = _hostname, _host, _parsed_host

--- a/dagshub/common/config.py
+++ b/dagshub/common/config.py
@@ -21,9 +21,21 @@ DAGSHUB_PASSWORD_KEY = "DAGSHUB_PASSWORD"
 HTTP_TIMEOUT_KEY = "DAGSHUB_HTTP_TIMEOUT"
 DAGSHUB_QUIET_KEY = "DAGSHUB_QUIET"
 
-parsed_host = urlparse(os.environ.get(HOST_KEY, DEFAULT_HOST))
-hostname = parsed_host.hostname
-host = parsed_host.geturl().rstrip("/")
+
+def set_host(new_host: str):
+    _parsed_host = urlparse(new_host)
+    _hostname = _parsed_host.hostname
+    _host = _parsed_host.geturl().rstrip("/")
+
+    global hostname, host, parsed_host
+    hostname, host, parsed_host = _hostname, _host, _parsed_host
+
+
+hostname = ""
+host = ""
+parsed_host = ""
+set_host(os.environ.get(HOST_KEY, DEFAULT_HOST))
+
 client_id = os.environ.get(CLIENT_ID_KEY, DEFAULT_CLIENT_ID)
 cache_location = os.environ.get(TOKENS_CACHE_LOCATION_KEY, DEFAULT_TOKENS_CACHE_LOCATION)
 token = os.environ.get(DAGSHUB_USER_TOKEN_KEY)
@@ -61,12 +73,3 @@ if download_threads > DEFAULT_DOWNLOAD_THREADS:
         f"Number of download threads was set to {download_threads}. "
         f"We recommend lowering the value if you get met with rate limits"
     )
-
-
-def set_host(new_host: str):
-    _parsed_host = urlparse(new_host)
-    _hostname = _parsed_host.hostname
-    _host = _parsed_host.geturl().rstrip("/")
-
-    global hostname, host, parsed_host
-    hostname, host, parsed_host = _hostname, _host, _parsed_host

--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -47,12 +47,15 @@ def init(
         root: Path to the locally hosted git repository.
             If it's not set, tries to find a repository traversing up the filesystem.
         host: Address of the DagsHub instance with the repository.
+            If specified, then all request to dagshub are going to be sent to this instance.
         mlflow: Configure MLflow to log experiments to DagsHub.
         dvc: Configure a dvc remote in the repository.
         patch_mlflow: Run :func:`dagshub.mlflow.patch_mlflow` so errors while logging with MLflow don't stop execution
     """
     if host is None:
         host = config.host
+    else:
+        config.set_host(host)
 
     if root is None:
         root = os.path.abspath(".")


### PR DESCRIPTION
Allows user to do:

```python
import dagshub
import mlflow

dagshub.init(repo_owner="user", repo_name="repo", host="https://some.other.dagshub")
with mlflow.start_run():
    mlflow.log_metric("aaa", 5)
```

The init will override the `config.host`, so all of the calls to dagshub will call the specified host instead.

