### PR TITLE
Bug: 2 install_hooks bugs

### DIFF
--- a/dagshub/streaming/dataclasses.py
+++ b/dagshub/streaming/dataclasses.py
@@ -25,8 +25,19 @@ class DagshubPath:
     # TODO: this couples this class hard to the fs, need to decouple later
     fs: "DagsHubFilesystem"  # Actual type is DagsHubFilesystem, but imports are wonky
     absolute_path: Optional[Path]
+    """
+    Absolute path in the OS filesystem
+    """
     relative_path: Optional[Path]
+    """
+    Path relative to the root of the repository the fs is hooked to.
+    """
     original_path: Optional[Path]
+    """
+    Original path requested by the user almost as-is (except for transformation to Path)
+    Required to keep listdir working correctly, since its behavior changes based on how it's being called
+    (relative vs. absolute path)
+    """
 
     def __post_init__(self):
         # Handle storage paths - translate s3:/bla-bla to .dagshub/storage/s3/bla-bla
@@ -35,9 +46,7 @@ class DagshubPath:
             for storage_schema in storage_schemas:
                 if str_path.startswith(f"{storage_schema}:/"):
                     str_path = str_path[len(storage_schema) + 2 :]
-                    self.relative_path = (
-                        Path(".dagshub/storage") / storage_schema / str_path
-                    )
+                    self.relative_path = Path(".dagshub/storage") / storage_schema / str_path
                     self.absolute_path = self.fs.project_root / self.relative_path
 
     @cached_property

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -326,15 +326,12 @@ class DagsHubFilesystem:
             DagsHubFilesystem.already_mounted_filesystems.pop(self.project_root)
 
     def _parse_path(self, file: Union[str, PathLike, int]) -> DagshubPath:
+        orig_path = Path(file)
         if isinstance(file, int):
-            return DagshubPath(self, None, None, Path(file))
+            return DagshubPath(self, None, None, orig_path)
         if file == "":
-            return DagshubPath(self, None, None, Path(file))
-
-        expanded = os.path.expanduser(file)
-        orig_path = Path(expanded)
-        abspath = Path(os.path.abspath(expanded))
-
+            return DagshubPath(self, None, None, orig_path)
+        abspath = Path(os.path.abspath(file))
         try:
             relpath = abspath.relative_to(os.path.abspath(self.project_root))
             if str(relpath).startswith("<"):

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -602,7 +602,7 @@ class DagsHubFilesystem:
         parsed_path = self._parse_path(str_path)
         if parsed_path.is_in_repo:
             if parsed_path.is_passthrough_path:
-                return self.listdir(parsed_path.original_path)
+                return self.__listdir(parsed_path.original_path)
             else:
                 dircontents: Set[str] = set()
                 error = None

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -326,12 +326,15 @@ class DagsHubFilesystem:
             DagsHubFilesystem.already_mounted_filesystems.pop(self.project_root)
 
     def _parse_path(self, file: Union[str, PathLike, int]) -> DagshubPath:
-        orig_path = Path(file)
         if isinstance(file, int):
-            return DagshubPath(self, None, None, orig_path)
+            return DagshubPath(self, None, None, Path(file))
         if file == "":
-            return DagshubPath(self, None, None, orig_path)
-        abspath = Path(os.path.abspath(file))
+            return DagshubPath(self, None, None, Path(file))
+
+        expanded = os.path.expanduser(file)
+        orig_path = Path(expanded)
+        abspath = Path(os.path.abspath(expanded))
+
         try:
             relpath = abspath.relative_to(os.path.abspath(self.project_root))
             if str(relpath).startswith("<"):


### PR DESCRIPTION
## Bug 1: Paths with `~` in them not getting expanded to the user home.
Example: 
```python
install_hooks(...)
with open("~/some/file.txt") as f:
    print(f.read())
```

The tilde wasn't being expanded and the wrong path was being read as a result (it was reading `$CWD/~/some/file.txt`)

## Bug 2: Recursive call in `DagsHubFilesystem.listdir()` for passthrough paths:
If accessing a passthrough directory inside a mounted fs (e.g. something with `site-packages`), the listdir of the fs kept calling itself instead of passing through to the OS filesystem.
Example:
```python
install_hooks(..., project_root=".")
print(os.listdir("./venv/site-packages"))
```