### PR TITLE
Bug: Fix ds.sample() crash

### DIFF
--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -275,7 +275,7 @@ class Datasource:
         if start is not None:
             logger.warning("Starting slices is not implemented for now")
         res = self._source.client.sample(self, end, include_metadata=True)
-        self._download_document_fields(res)
+        res._load_autoload_fields(documents=load_documents, annotations=load_annotations)
         return res
 
     def head(self, size=100, load_documents=True, load_annotations=True) -> "QueryResult":

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -275,7 +275,7 @@ class Datasource:
         if start is not None:
             logger.warning("Starting slices is not implemented for now")
         res = self._source.client.sample(self, end, include_metadata=True)
-        res._load_autoload_fields(documents=load_documents, annotations=load_annotations)
+        res._load_autoload_fields()
         return res
 
     def head(self, size=100, load_documents=True, load_annotations=True) -> "QueryResult":


### PR DESCRIPTION
Doing a `ds[:100]` tries to call a refactored-away function that I didn't catch.
Fixing this in this PR