### PR TITLE
Bug: Fix incorrect is_not_null() implementation

### DIFF
--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -1560,7 +1560,9 @@ class Datasource:
 
         :meta private:
         """
-        return self.is_null().add_query_op("not")
+        field = self._get_filtering_field()
+        value_type = metadataTypeLookupReverse[field.valueType.value]
+        return self.add_query_op("!isnull", value_type())
 
     def _get_filtering_field(self) -> MetadataFieldSchema:
         field_name = self.get_query().filter.column_filter

--- a/dagshub/data_engine/model/query.py
+++ b/dagshub/data_engine/model/query.py
@@ -147,6 +147,13 @@ class QueryFilterTree:
         if self._column_filter_node is not None:
             # If there was an unfilled query node with a column - put the operand in that node
             node = self._column_filter_node
+            if op.startswith("!"):
+                # Negation in the operation - prepend a not node before the current node
+                tree = self._operand_tree
+                parent_id = tree.parent(node.identifier)
+                not_node = tree.create_node("not", parent=parent_id)
+                tree.move_node(node.identifier, not_node.identifier)
+                op = op[1:]
             node.tag = op
             node.data.update({"value": other})
         elif op == "isnull":


### PR DESCRIPTION
Before this PR running a query like:
```python
q = ds["col1"] > 2
q = q["col2"].is_not_null()
```

Will lead to building a query tree resolving to `NOT (col1 > 2  AND col2 IS NULL)`
The expected query for this code should have been `col1 > 2 AND NOT (col2 IS NULL)`

This PR fixes it by introducing a `!` prefix on a QueryTree operand, that makes it so the operand gets prepended with a `not` node, which how you would expect an `is_not_null` to behave 

Added a test for this. Everything in `test_querying.py` after line 560 is just autoformatting.