### PR TITLE
Enhancement: Make the visualization URL shorter if there's no query

### DIFF
--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -1045,8 +1045,12 @@ class Datasource:
         """
         Returns a query that is parseable by the frontend.
         It has to be a JSON of the GraphQL query, encoded into b64
+
+        This also omits any null values to make the resulting URL shorter
         """
-        params = self._query.to_json()
+        params_dict = self._query.to_dict()
+        params_dict = {k: v for k, v in params_dict.items() if v is not None}
+        params = json.dumps(params_dict)
         params_encoded = base64.urlsafe_b64encode(params.encode("utf-8")).decode("utf-8")
         return f"query={params_encoded}"
 


### PR DESCRIPTION
This PR shortens the encoded JSON that gets sent for visualization.
Before this PR an empty query will result in encoding a JSON like:
```json
{"query": null}
```

After this PR the null values will be omitted, so the result would be just `{}`