### PR TITLE
Tests: Fix broken tests on new httpx version

### DIFF
--- a/tests/dda/conftest.py
+++ b/tests/dda/conftest.py
@@ -32,7 +32,9 @@ def current_revision(dagshub_repo: pytest_git.GitRepo) -> str:
 
 @pytest.fixture
 def mock_api(dagshub_repo: pytest_git.GitRepo) -> MockApi:
-    with MockApi(git_repo=dagshub_repo, base_url="https://dagshub.com", assert_all_called=False) as respx_mock:
+    with MockApi(
+        git_repo=dagshub_repo, base_url="https://dagshub.com", assert_all_called=False, using="httpx"
+    ) as respx_mock:
         yield respx_mock
 
 

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -340,8 +340,6 @@ class MockApi(MockRouter):
                 "timestamp": "2021-08-10T09:03:32Z",
             }
         }
-        url = f"/api/v1/repos/{self.repourlpath}/commits/{revision}"
-        print(f"Adding mock for url: {url}")
-        branch_route = self.get(url=url)
+        branch_route = self.get(url=f"/api/v1/repos/{self.repourlpath}/commits/{revision}")
         branch_route.mock(Response(200, json=resp_json))
         return branch_route

--- a/tests/dda/mock_api.py
+++ b/tests/dda/mock_api.py
@@ -340,6 +340,8 @@ class MockApi(MockRouter):
                 "timestamp": "2021-08-10T09:03:32Z",
             }
         }
-        branch_route = self.get(url=f"/api/v1/repos/{self.repourlpath}/commits/{revision}")
+        url = f"/api/v1/repos/{self.repourlpath}/commits/{revision}"
+        print(f"Adding mock for url: {url}")
+        branch_route = self.get(url=url)
         branch_route.mock(Response(200, json=resp_json))
         return branch_route


### PR DESCRIPTION
Respx is broken with the new httpx version, this PR fixes it for tests
Issue in respx repo with the workaround: https://github.com/lundberg/respx/issues/277