### PR TITLE
Bug: Loading a model from the root of a bucket has to have a trailing slash in the path

### DIFF
--- a/dagshub/common/util.py
+++ b/dagshub/common/util.py
@@ -2,7 +2,8 @@ import datetime
 import types
 import logging
 import importlib
-from typing import Union
+from pathlib import PurePath
+from typing import Union, TypeVar
 from urllib.parse import urljoin, quote
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,18 @@ def lazy_load(module_name, source_package=None, callback=None):
         # TODO: need to have a map for commonly used imports here. Also handle dots
         source_package = module_name
     return LazyModule(module_name, source_package, callback)
+
+
+pathSubclass = TypeVar("pathSubclass", bound=PurePath)
+
+
+def is_path_relative_to(path_a: pathSubclass, path_b: pathSubclass) -> bool:
+    # Polyfill of Path.is_relative
+    try:
+        path_a.relative_to(path_b)
+        return True
+    except ValueError:
+        return False
 
 
 class LazyModule(types.ModuleType):

--- a/dagshub/models/model_locator.py
+++ b/dagshub/models/model_locator.py
@@ -86,11 +86,7 @@ class ModelLocator:
     def download_destination(self) -> Path:
         if self._download_dest is not None:
             return Path(self._download_dest)
-        return Path(
-            sanitize_filepath(
-                os.path.join(Path.home(), "dagshub", "models", self.repo_api.full_name)
-            )
-        )
+        return Path(sanitize_filepath(os.path.join(Path.home(), "dagshub", "models", self.repo_api.full_name)))
 
     @cached_property
     def repo_storages(self) -> List[StorageAPIEntry]:
@@ -99,7 +95,7 @@ class ModelLocator:
     def _handle_path(self, path: str) -> Tuple[str, StorageType]:
         """
         Handles user-printed path.
-        Returns a resulting path that can be queried from DagsHub + boolean for whether it's a repo or a bucket path
+        Returns a resulting path that can be queried from DagsHub + enum for whether it's a repo or a bucket path
         If path is a repo path, returns (path as is, StorageType.Repo)
         If path is a storage path, ({actual path in storage} + StorageType.Bucket/DagshubStorage)
         Storage path resolution is based on bucket name, if the path starts with a name of an existing bucket,
@@ -113,7 +109,7 @@ class ModelLocator:
         if str_path.startswith("dagshub_storage/"):
             return str_path[len("dagshub_storage/") :], StorageType.DagshubStorage
         for storage in self.repo_storages:
-            if str_path.startswith(f"{storage.name}/"):
+            if str_path.startswith(f"{storage.name}"):
                 bucketPath = f"{storage.protocol}/{str_path}"
                 return bucketPath, StorageType.Bucket
         return path, StorageType.Repo
@@ -132,24 +128,18 @@ class ModelLocator:
         log_message(f"Loading the model from yaml file {yaml_path}", logger=logger)
         if storage_type == StorageType.DagshubStorage:
             try:
-                self.repo_api.list_storage_path(
-                    f"s3/{self.repo_api.repo_name}/{model_path}"
-                )
+                self.repo_api.list_storage_path(f"s3/{self.repo_api.repo_name}/{model_path}")
                 log_message(
                     f"Loading the model from DagsHub Storage {model_path}",
                     logger=logger,
                 )
-                return DagsHubStorageModelLoader(
-                    self.repo_api, PurePosixPath(model_path)
-                )
+                return DagsHubStorageModelLoader(self.repo_api, PurePosixPath(model_path))
             except PathNotFoundError:
                 raise ModelNotFoundError
         elif storage_type == StorageType.Bucket:
             try:
                 self.repo_api.list_storage_path(model_path)
-                log_message(
-                    f"Loading the model from bucket {model_path}", logger=logger
-                )
+                log_message(f"Loading the model from bucket {model_path}", logger=logger)
                 return BucketModelLoader(self.repo_api, PurePosixPath(model_path))
             except PathNotFoundError:
                 raise ModelNotFoundError
@@ -157,9 +147,7 @@ class ModelLocator:
             try:
                 self.repo_api.list_path(model_path, revision=self.git_ref)
                 log_message(f"Loading the model from repo {model_path}", logger=logger)
-                return RepoModelLoader(
-                    self.repo_api, self.git_ref, PurePosixPath(model_path)
-                )
+                return RepoModelLoader(self.repo_api, self.git_ref, PurePosixPath(model_path))
             except PathNotFoundError:
                 raise ModelNotFoundError
 
@@ -170,12 +158,8 @@ class ModelLocator:
             modelPath = PurePosixPath(lookup_dir)
             try:
                 self.repo_api.list_path(str(modelPath), revision=self.git_ref)
-                log_message(
-                    f"Loading the model from repo directory {modelPath}", logger=logger
-                )
-                return RepoModelLoader(
-                    repo_api=self.repo_api, revision=self.git_ref, path=modelPath
-                )
+                log_message(f"Loading the model from repo directory {modelPath}", logger=logger)
+                return RepoModelLoader(repo_api=self.repo_api, revision=self.git_ref, path=modelPath)
             except PathNotFoundError:
                 continue
         return None
@@ -213,9 +197,7 @@ class ModelLocator:
                     f"Loading the model from DagsHub Storage directory {modelPath}",
                     logger=logger,
                 )
-                return DagsHubStorageModelLoader(
-                    repo_api=self.repo_api, path=PurePosixPath(modelPath)
-                )
+                return DagsHubStorageModelLoader(repo_api=self.repo_api, path=PurePosixPath(modelPath))
             except PathNotFoundError:
                 continue
 
@@ -232,17 +214,11 @@ class ModelLocator:
                     self.repo_api.list_storage_path(handled_path)
                     return BucketModelLoader(self.repo_api, PurePosixPath(handled_path))
                 elif storage_type == storage_type.DagshubStorage:
-                    self.repo_api.list_storage_path(
-                        PurePosixPath("s3") / self.repo_api.repo_name / handled_path
-                    )
-                    return DagsHubStorageModelLoader(
-                        self.repo_api, PurePosixPath(handled_path)
-                    )
+                    self.repo_api.list_storage_path(PurePosixPath("s3") / self.repo_api.repo_name / handled_path)
+                    return DagsHubStorageModelLoader(self.repo_api, PurePosixPath(handled_path))
                 else:
                     self.repo_api.list_path(handled_path, self.git_ref)
-                    return RepoModelLoader(
-                        self.repo_api, self.git_ref, PurePosixPath(handled_path)
-                    )
+                    return RepoModelLoader(self.repo_api, self.git_ref, PurePosixPath(handled_path))
             except PathNotFoundError:
                 raise ModelNotFoundError
 
@@ -272,9 +248,7 @@ class ModelLocator:
     def get_model_path(self) -> Path:
         send_analytics_event("Client_Models_GetModelPath")
         model_loader = self.find_model()
-        return model_loader.load_model(
-            self.download_type, self.download_destination, self.git_ref
-        )
+        return model_loader.load_model(self.download_type, self.download_destination, self.git_ref)
 
 
 def get_model_path(

--- a/dagshub/models/model_locator.py
+++ b/dagshub/models/model_locator.py
@@ -16,6 +16,7 @@ from dagshub.common.api.repo import PathNotFoundError
 from dagshub.common.api.responses import StorageAPIEntry
 from dagshub.common.determine_repo import determine_repo
 from dagshub.common.helpers import log_message
+from dagshub.common.util import is_path_relative_to
 from dagshub.models.model_loaders import (
     ModelLoader,
     RepoModelLoader,
@@ -111,7 +112,7 @@ class ModelLocator:
         in_path = PurePosixPath(str_path)
         for storage in self.repo_storages:
             storage_path = PurePosixPath(storage.name)
-            if in_path.is_relative_to(storage_path):
+            if is_path_relative_to(in_path, storage_path):
                 bucketPath = f"{storage.protocol}/{str_path}"
                 return bucketPath, StorageType.Bucket
         return path, StorageType.Repo

--- a/dagshub/models/model_locator.py
+++ b/dagshub/models/model_locator.py
@@ -108,8 +108,10 @@ class ModelLocator:
 
         if str_path.startswith("dagshub_storage/"):
             return str_path[len("dagshub_storage/") :], StorageType.DagshubStorage
+        in_path = PurePosixPath(str_path)
         for storage in self.repo_storages:
-            if str_path.startswith(f"{storage.name}"):
+            storage_path = PurePosixPath(storage.name)
+            if in_path.is_relative_to(storage_path):
                 bucketPath = f"{storage.protocol}/{str_path}"
                 return bucketPath, StorageType.Bucket
         return path, StorageType.Repo

--- a/dagshub/models/model_locator.py
+++ b/dagshub/models/model_locator.py
@@ -94,12 +94,12 @@ class ModelLocator:
 
     def _handle_path(self, path: str) -> Tuple[str, StorageType]:
         """
-        Handles user-printed path.
-        Returns a resulting path that can be queried from DagsHub + enum for whether it's a repo or a bucket path
+        Handles user-printed path, determining where it belongs (repo, bucket or repo's bucket).
+
         If path is a repo path, returns (path as is, StorageType.Repo)
         If path is a storage path, ({actual path in storage} + StorageType.Bucket/DagshubStorage)
         Storage path resolution is based on bucket name, if the path starts with a name of an existing bucket,
-        assume that it's a storage path
+        then greedily return that bucket as the bucket with the path.
         """
         str_path = str(path)
 

--- a/tests/mocks/repo_api.py
+++ b/tests/mocks/repo_api.py
@@ -8,8 +8,7 @@ from dagshub.common.api.repo import PathNotFoundError
 from dagshub.common.api.responses import StorageAPIEntry, ContentAPIEntry, CommitAPIResponse
 
 
-class MockError(Exception):
-    ...
+class MockError(Exception): ...
 
 
 class MockRepoAPI(RepoAPI):
@@ -142,7 +141,7 @@ class MockRepoAPI(RepoAPI):
         return content
 
     def list_storage_path(self, path: str, include_size: bool = False) -> List[ContentAPIEntry]:
-        content = self.storage_contents.get(path)
+        content = self.storage_contents.get(path.rstrip("/"))
         if content is None:
             raise PathNotFoundError
         return content

--- a/tests/model_loading/test_locate.py
+++ b/tests/model_loading/test_locate.py
@@ -58,6 +58,16 @@ def test_found_when_passed_path(repo_mock):
     assert loader.path == PosixPath(dir_path)
 
 
+def test_found_when_passed_bucket_root_as_path(repo_mock):
+    bucket_name = "some-bucket/random/prefix"
+    repo_mock.add_storage("s3", bucket_name)
+    repo_mock.add_storage_file(f"s3/{bucket_name}/model.pt", b"blablabla")
+    locator = ModelLocator(repo_mock, path=bucket_name)
+    loader = locator.find_model()
+    assert isinstance(loader, BucketModelLoader)
+    assert loader.path == PosixPath(f"s3/{bucket_name}")
+
+
 def test_raises_when_passed_path_and_not_found(repo_with_repo_model):
     # The existing model should be ignored
     repo_mock, _ = repo_with_repo_model


### PR DESCRIPTION
Fixes the usecase where:

- A model is stored in the root of a bucket like `bucket/some/prefix`
- The model is trying to be loaded with the following code:
```python
# This works
# bucket_name='bucket/some/prefix/'
# This fails without a trailing slash
bucket_name='bucket/some/prefix'

get_model_path("user/repo", path=bucket_name)
```

Switching for the bucket name with the slash works.

Also added a test case for this bug.

Most of the lines changed are reformats