### PR TITLE
Fix: Remove tha artifact_name argument from ds.log_to_mlflow()

### DIFF
--- a/dagshub/common/util.py
+++ b/dagshub/common/util.py
@@ -30,6 +30,12 @@ def to_timestamp(ts: Union[float, int, datetime.datetime]) -> int:
         return int(ts)
 
 
+def removeprefix(val: str, prefix: str) -> str:
+    if val.startswith(prefix):
+        return val[len(prefix) :]
+    return val
+
+
 def lazy_load(module_name, source_package=None, callback=None):
     if source_package is None:
         # TODO: need to have a map for commonly used imports here. Also handle dots

--- a/dagshub/common/util.py
+++ b/dagshub/common/util.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import types
 import logging
 import importlib
@@ -94,3 +95,24 @@ class LazyModule(types.ModuleType):
         # Update this object's dict so that attribute references are efficient
         # (__getattr__ is only called on lookups that fail)
         self.__dict__.update(module.__dict__)
+
+
+def deprecated(additional_message=""):
+    """
+    Decorator to mark functions as deprecated. It will print a warning
+    message when the function is called.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            additional = "\n" + additional_message if additional_message else ""
+            logger.warning(
+                f"DagsHub Deprecation Warning: "
+                f"{func.__name__} is deprecated and may be removed in future versions.{additional}",
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/dagshub/data_engine/datasets.py
+++ b/dagshub/data_engine/datasets.py
@@ -4,7 +4,7 @@ from dagshub.common.analytics import send_analytics_event
 from dagshub.data_engine.client.data_client import DataClient
 from dagshub.data_engine.client.models import DatasetResult
 from dagshub.data_engine import datasources
-from dagshub.data_engine.model.datasource import Datasource, DEFAULT_MLFLOW_ARTIFACT_NAME, DatasetState
+from dagshub.data_engine.model.datasource import Datasource, DatasetState
 from dagshub.data_engine.model.datasource_state import DatasourceState
 from dagshub.data_engine.model.errors import DatasetNotFoundError
 
@@ -61,7 +61,7 @@ def get_dataset_from_file(path: str) -> Datasource:
     return datasources.get_datasource_from_file(path)
 
 
-def get_from_mlflow(run=None, artifact_name=DEFAULT_MLFLOW_ARTIFACT_NAME) -> Datasource:
+def get_from_mlflow(run=None, artifact_name: Optional[str] = None) -> Datasource:
     """
     Load a dataset from an MLflow run.
 

--- a/dagshub/data_engine/datasets.py
+++ b/dagshub/data_engine/datasets.py
@@ -66,7 +66,7 @@ def get_from_mlflow(run=None, artifact_name: Optional[str] = None) -> Datasource
     Load a dataset from an MLflow run.
 
     To save a datasource to MLflow, use
-    :func:`Datasource.log_to_mlflow()<dagshub.data_engine.model.datasource.Datasource.log_to_mlflow>`.
+    :func:`QueryResult.log_to_mlflow()<dagshub.data_engine.model.query_result.QueryResult.log_to_mlflow>`.
 
     This is a copy of :func:`datasources.get_from_mlflow()<dagshub.data_engine.datasources.get_from_mlflow>`
 

--- a/dagshub/data_engine/datasets.py
+++ b/dagshub/data_engine/datasets.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from dagshub.common.analytics import send_analytics_event
 from dagshub.data_engine.client.data_client import DataClient
@@ -61,9 +61,9 @@ def get_dataset_from_file(path: str) -> Datasource:
     return datasources.get_datasource_from_file(path)
 
 
-def get_from_mlflow(run=None, artifact_name: Optional[str] = None) -> Datasource:
+def get_from_mlflow(run=None, artifact_name: Optional[str] = None) -> Dict[str, Datasource]:
     """
-    Load a dataset from an MLflow run.
+    Load datasets from an MLflow run.
 
     To save a datasource to MLflow, use
     :func:`QueryResult.log_to_mlflow()<dagshub.data_engine.model.query_result.QueryResult.log_to_mlflow>`.
@@ -74,6 +74,10 @@ def get_from_mlflow(run=None, artifact_name: Optional[str] = None) -> Datasource
         run: Run or ID of the MLflow run to load the datasource from.
             If ``None``, gets it from the current active run.
         artifact_name: Name of the artifact in the run.
+            If specified, will only return the dataset defined in this artifact.
+
+    Returns:
+        Dictionary where keys are the artifacts, and the values are the dataset stored in the artifact.
     """
     return datasources.get_from_mlflow(run, artifact_name)
 

--- a/dagshub/data_engine/datasources.py
+++ b/dagshub/data_engine/datasources.py
@@ -175,7 +175,7 @@ def get_from_mlflow(
     Load a datasource from an MLflow run.
 
     To save a datasource to MLflow, use
-    :func:`Datasource.log_to_mlflow()<dagshub.data_engine.model.datasource.Datasource.log_to_mlflow>`.
+    :func:`QueryResult.log_to_mlflow()<dagshub.data_engine.model.query_result.QueryResult.log_to_mlflow>`.
 
     Args:
         run: MLflow Run or its ID to load the datasource from.

--- a/dagshub/data_engine/datasources.py
+++ b/dagshub/data_engine/datasources.py
@@ -6,7 +6,7 @@ from dagshub.common.analytics import send_analytics_event
 from dagshub.common.api.repo import RepoAPI
 from dagshub.common.util import lazy_load
 from dagshub.data_engine.client.data_client import DataClient
-from dagshub.data_engine.model.datasource import Datasource, DEFAULT_MLFLOW_ARTIFACT_NAME
+from dagshub.data_engine.model.datasource import Datasource
 from dagshub.data_engine.model.datasource_state import DatasourceState, DatasourceType, path_regexes
 from dagshub.data_engine.model.errors import DatasourceNotFoundError
 
@@ -169,7 +169,7 @@ def get_datasources(repo: str) -> List[Datasource]:
 
 
 def get_from_mlflow(
-    run: Optional[Union["mlflow.entities.Run", str]] = None, artifact_name=DEFAULT_MLFLOW_ARTIFACT_NAME
+    run: Optional[Union["mlflow.entities.Run", str]] = None, artifact_name: Optional[str] = None
 ) -> Datasource:
     """
     Load a datasource from an MLflow run.
@@ -189,6 +189,9 @@ def get_from_mlflow(
         mlflow_run = mlflow.get_run(run)
     else:
         mlflow_run = run
+
+    if artifact_name is None:
+        raise ValueError("artifact_name must be specified")
 
     artifact_uri: str = mlflow_run.info.artifact_uri
     artifact_path = f"{artifact_uri.rstrip('/')}/{artifact_name.lstrip('/')}"

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -867,7 +867,7 @@ class Datasource:
         now_time = datetime.datetime.now.strftime("%Y-%m-%dT%H-%M-%S")  # Not ISO format to make it a valid filename
         uuid_chunk = str(uuid.uuid4())[-4:]
 
-        artifact_name = f"log_{self.source.name}_{now_time}_{uuid_chunk}.dagshub.json"
+        artifact_name = f"log_{self.source.name}_{now_time}_{uuid_chunk}.dagshub.dataset.json"
 
         return self._log_to_mlflow(artifact_name, run, as_of)
 
@@ -883,7 +883,7 @@ class Datasource:
         now_time = qr.query_data_time.strftime("%Y-%m-%dT%H-%M-%S")  # Not ISO format to make it a valid filename
         uuid_chunk = str(uuid.uuid4())[-4:]
 
-        artifact_name = f"autolog_{source_name}_{now_time}_{uuid_chunk}.dagshub.json"
+        artifact_name = f"autolog_{source_name}_{now_time}_{uuid_chunk}.dagshub.dataset.json"
         threading.Thread(
             target=self._log_to_mlflow,
             kwargs={"artifact_name": artifact_name, "run": active_run, "as_of": qr.query_data_time},

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -844,7 +844,7 @@ class Datasource:
         copy_with_ds_assigned.load_from_dataset(dataset_name=name, change_query=False)
         return copy_with_ds_assigned
 
-    @deprecated("Either use autologging, or QueryResult.log_to_mlflow() if there autologging is turned off")
+    @deprecated("Either use autologging, or QueryResult.log_to_mlflow() if autologging is turned off")
     def log_to_mlflow(
         self,
         artifact_name: Optional[str] = None,

--- a/dagshub/data_engine/model/datasource.py
+++ b/dagshub/data_engine/model/datasource.py
@@ -77,7 +77,6 @@ else:
 logger = logging.getLogger(__name__)
 
 LS_ORCHESTRATOR_URL = "http://127.0.0.1"
-DEFAULT_MLFLOW_ARTIFACT_NAME = "datasource.dagshub.json"
 MLFLOW_DATASOURCE_TAG_NAME = "dagshub.datasets.datasource_id"
 MLFLOW_DATASET_TAG_NAME = "dagshub.datasets.dataset_id"
 


### PR DESCRIPTION
This PR makes it so the users can no longer supply the `artifact_name` argument to the `ds.log_to_mlflow()` function.