### PR TITLE
Feature: Datapoint version history

### DIFF
--- a/dagshub/data_engine/client/data_client.py
+++ b/dagshub/data_engine/client/data_client.py
@@ -397,6 +397,7 @@ class DataClient:
     ) -> Dict[str, List[DatapointHistoryResult]]:
         ds_id = datapoints[0].datasource.source.id
         assert ds_id is not None
+        assert len(datapoints) > 0
 
         after = None
         hasNextPage = True

--- a/dagshub/data_engine/client/gql_introspections.py
+++ b/dagshub/data_engine/client/gql_introspections.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 import functools
 from typing import Any, Dict, List
-from dagshub.data_engine.client.query_builder import GqlQuery
+from dagshub.data_engine.client.query_builder import GqlQuery, ParamValidator
 
 
 class GqlIntrospections:
     @staticmethod
     @functools.lru_cache()
-    def obj_fields() -> str:
+    def obj_fields() -> GqlQuery:
         q = (
             GqlQuery()
             .operation("query", name="introspection")
@@ -36,7 +36,6 @@ class GqlIntrospections:
                     .generate()
                 ]
             )
-            .generate()
         )
         return q
 
@@ -102,3 +101,13 @@ class Validators:
         root_fields = [f.split(" ")[0] for f in fields]
         supported_fields = Validators.get_fields(introspection, response_obj_name)
         return [fields[i] for i, rf in enumerate(root_fields) if rf in supported_fields]
+
+    @staticmethod
+    def has_type_validator(type_name: str) -> "ParamValidator":
+        def validator(_: Dict[str, Any], introspection: TypesIntrospection):
+            if type_name not in [t.name for t in introspection.types]:
+                raise ValueError(
+                    f"{type_name} is not allowed on the backend. Make sure your DagsHub instance is up to date"
+                )
+
+        return validator

--- a/dagshub/data_engine/client/gql_introspections.py
+++ b/dagshub/data_engine/client/gql_introspections.py
@@ -107,7 +107,7 @@ class Validators:
         def validator(_: Dict[str, Any], introspection: TypesIntrospection):
             if type_name not in [t.name for t in introspection.types]:
                 raise ValueError(
-                    f"{type_name} is not allowed on the backend. Make sure your DagsHub instance is up to date"
+                    f"{type_name} is not available on the backend. Make sure your DagsHub instance is up to date"
                 )
 
         return validator

--- a/dagshub/data_engine/client/gql_mutations.py
+++ b/dagshub/data_engine/client/gql_mutations.py
@@ -19,7 +19,6 @@ class GqlMutations:
             )
             .query("createDatasource", input={"name": "$name", "url": "$url", "dsType": "$dsType"})
             .fields(["id", "name", "rootUrl", "integrationStatus", "preprocessingStatus", "type"])
-            .generate()
         )
         return q
 
@@ -43,7 +42,6 @@ class GqlMutations:
                     "path",
                 ]
             )
-            .generate()
         )
         return q
 
@@ -63,7 +61,6 @@ class GqlMutations:
                     "path",
                 ]
             )
-            .generate()
         )
         return q
 
@@ -83,7 +80,6 @@ class GqlMutations:
                     "path",
                 ]
             )
-            .generate()
         )
         return q
 
@@ -106,7 +102,6 @@ class GqlMutations:
                     "tags",
                 ]
             )
-            .generate()
         )
         return q
 
@@ -131,6 +126,7 @@ class GqlMutations:
             "datapoints": datapoints,
         }
 
+    @staticmethod
     def update_metadata_fields_params(datasource_id: Union[int, str], metadata_field_props: List[Dict[str, Any]]):
         return {"datasource": datasource_id, "props": metadata_field_props}
 
@@ -162,7 +158,6 @@ class GqlMutations:
                     "type",
                 ]
             )
-            .generate()
         )
         return q
 
@@ -202,7 +197,6 @@ class GqlMutations:
                     "type",
                 ]
             )
-            .generate()
         )
         return q
 
@@ -231,7 +225,6 @@ class GqlMutations:
                     "createdAt",
                 ]
             )
-            .generate()
         )
         return q
 
@@ -251,7 +244,6 @@ class GqlMutations:
             .operation("mutation", name="deleteDataset", input={"$id": "ID!"})
             .query("deleteDataset", input={"id": "$id"})
             .fields(["id"])
-            .generate()
         )
         return q
 

--- a/dagshub/data_engine/client/gql_queries.py
+++ b/dagshub/data_engine/client/gql_queries.py
@@ -1,5 +1,6 @@
+import datetime
 import functools
-from typing import Optional, Any, Dict, Union
+from typing import Optional, Any, Dict, Union, List
 
 from dagshub.data_engine.client.gql_introspections import Validators, TypesIntrospection
 from dagshub.data_engine.client.query_builder import GqlQuery
@@ -122,4 +123,46 @@ class GqlQueries:
         return {
             "id": id,
             "name": name,
+        }
+
+    @staticmethod
+    @functools.lru_cache()
+    def datapoint_history() -> GqlQuery:
+        q = (
+            GqlQuery()
+            .operation(
+                "query",
+                name="datapointHistory",
+                input={
+                    "$datasource": "ID!",
+                    "$opts": "DatapointHistoryInput!",
+                },
+            )
+            .query(
+                "datapointHistory",
+                input={
+                    "datasource": "$datasource",
+                    "opts": "$opts",
+                },
+            )
+            .fields(["timestamp"])
+        )
+        return q
+
+    @staticmethod
+    def datapoint_history_params(
+        datasource_id: Union[int, str],
+        datapoints: List[str],
+        fields: Optional[List[str]],
+        from_time: Optional[datetime.datetime],
+        to_time: Optional[datetime.datetime],
+    ) -> Dict[str, Any]:
+        return {
+            "datasource": datasource_id,
+            "opts": {
+                "datapoints": datapoints,
+                "fields": fields,
+                "fromTime": int(from_time.timestamp()) if from_time else None,
+                "toTime": int(to_time.timestamp()) if to_time else None,
+            },
         }

--- a/dagshub/data_engine/client/gql_queries.py
+++ b/dagshub/data_engine/client/gql_queries.py
@@ -153,6 +153,7 @@ class GqlQueries:
                 ]
             )
         )
+        q.param_validator(Validators.has_type_validator("DatapointHistory"))
         return q
 
     @staticmethod

--- a/dagshub/data_engine/client/gql_queries.py
+++ b/dagshub/data_engine/client/gql_queries.py
@@ -128,6 +128,7 @@ class GqlQueries:
     @staticmethod
     @functools.lru_cache()
     def datapoint_history() -> GqlQuery:
+        # TODO: introspect and check if the query is available
         q = (
             GqlQuery()
             .operation(
@@ -145,7 +146,12 @@ class GqlQueries:
                     "opts": "$opts",
                 },
             )
-            .fields(["timestamp"])
+            .fields(
+                [
+                    "edges { node { path history { timestamp } } }",
+                    "pageInfo { hasNextPage endCursor }",
+                ]
+            )
         )
         return q
 
@@ -156,6 +162,8 @@ class GqlQueries:
         fields: Optional[List[str]],
         from_time: Optional[datetime.datetime],
         to_time: Optional[datetime.datetime],
+        after: Optional[str],
+        first: Optional[int],
     ) -> Dict[str, Any]:
         return {
             "datasource": datasource_id,
@@ -164,5 +172,7 @@ class GqlQueries:
                 "fields": fields,
                 "fromTime": int(from_time.timestamp()) if from_time else None,
                 "toTime": int(to_time.timestamp()) if to_time else None,
+                "after": after if after else None,
+                "first": first if first else None,
             },
         }

--- a/dagshub/data_engine/client/models.py
+++ b/dagshub/data_engine/client/models.py
@@ -123,4 +123,4 @@ class DatasetResult:
 @dataclass
 class DatapointHistoryResult:
     timestamp: datetime.datetime
-    """Time of the version change for this datapoint. The timezone is always UTC."""
+    """Times of the version changes for this datapoint. The timezone is always UTC."""

--- a/dagshub/data_engine/client/models.py
+++ b/dagshub/data_engine/client/models.py
@@ -1,3 +1,4 @@
+import datetime
 import enum
 import logging
 from dataclasses import dataclass, field
@@ -117,3 +118,9 @@ class DatasetResult:
     name: str
     datasource: DatasourceResult
     datasetQuery: str
+
+
+@dataclass
+class DatapointHistoryResult:
+    timestamp: datetime.datetime
+    """Time of the version change for this datapoint. The timezone is always UTC."""

--- a/dagshub/data_engine/model/datapoint.py
+++ b/dagshub/data_engine/model/datapoint.py
@@ -259,7 +259,8 @@ class Datapoint:
         Returns:
             List of objects with information about the versions.
         """
-        return self.datasource.source.client.get_datapoint_history([self], fields, from_time, to_time)
+        history = self.datasource.source.client.get_datapoint_history([self], fields, from_time, to_time)
+        return history.get(self.path, [])
 
 
 def _get_blob(

--- a/dagshub/data_engine/model/datapoint.py
+++ b/dagshub/data_engine/model/datapoint.py
@@ -10,7 +10,7 @@ from tenacity import Retrying, stop_after_attempt, wait_exponential, before_slee
 from dagshub.common.download import download_files
 from dagshub.common.helpers import http_request
 from dagshub.data_engine.annotation import MetadataAnnotations
-from dagshub.data_engine.client.models import MetadataSelectFieldSchema
+from dagshub.data_engine.client.models import MetadataSelectFieldSchema, DatapointHistoryResult
 from dagshub.data_engine.dtypes import MetadataFieldType
 
 if TYPE_CHECKING:
@@ -241,6 +241,25 @@ class Datapoint:
 
     def blob_url(self, sha):
         return self.datasource.source.blob_path(sha)
+
+    def get_version_timestamps(
+        self,
+        fields: Optional[List[str]] = None,
+        from_time: Optional[datetime.datetime] = None,
+        to_time: Optional[datetime.datetime] = None,
+    ) -> List[DatapointHistoryResult]:
+        """
+        Get the timestamps of all versions of this datapoint, where the specified fields have changed.
+
+        Args:
+            fields: List of fields to check for changes. If None, all fields are checked.
+            from_time: Only search versions since this time. If None, the start time is unbounded
+            to_time: Only search versions until this time. If None, the end time is unbounded
+
+        Returns:
+            List of objects with information about the versions.
+        """
+        return self.datasource.source.client.get_datapoint_history([self], fields, from_time, to_time)
 
 
 def _get_blob(

--- a/dagshub/data_engine/model/schema_util.py
+++ b/dagshub/data_engine/model/schema_util.py
@@ -19,8 +19,10 @@ metadataTypeLookupReverse: Dict[str, Type] = {}
 for k, v in metadataTypeLookup.items():
     metadataTypeLookupReverse[v.value] = k
 
+
 def timestamp_to_datetime(timestamp: int) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+
 
 dacite_config = dacite.Config(
     cast=[IntegrationStatus, DatasourceType, PreprocessingStatus, MetadataFieldType, Set],

--- a/dagshub/data_engine/model/schema_util.py
+++ b/dagshub/data_engine/model/schema_util.py
@@ -19,4 +19,10 @@ metadataTypeLookupReverse: Dict[str, Type] = {}
 for k, v in metadataTypeLookup.items():
     metadataTypeLookupReverse[v.value] = k
 
-dacite_config = dacite.Config(cast=[IntegrationStatus, DatasourceType, PreprocessingStatus, MetadataFieldType, Set])
+def timestamp_to_datetime(timestamp: int) -> datetime.datetime:
+    return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+
+dacite_config = dacite.Config(
+    cast=[IntegrationStatus, DatasourceType, PreprocessingStatus, MetadataFieldType, Set],
+    type_hooks={datetime.datetime: timestamp_to_datetime},
+)

--- a/docs/source/reference/data_engine/datapoint.rst
+++ b/docs/source/reference/data_engine/datapoint.rst
@@ -3,3 +3,6 @@ Datapoint
 
 .. autoclass:: dagshub.data_engine.model.datapoint.Datapoint
     :members:
+
+.. autoclass:: dagshub.data_engine.client.models.DatapointHistoryResult
+    :members:


### PR DESCRIPTION
Add a function `Datapoint.get_version_timestamps()` that allows to fetch version history from the backend.

Signature + docs of the function:
```python
def get_version_timestamps(
    self,
    fields: Optional[List[str]] = None,
    from_time: Optional[datetime.datetime] = None,
    to_time: Optional[datetime.datetime] = None,
) -> List[DatapointHistoryResult]:
    """
    Get the timestamps of all versions of this datapoint, where the specified fields have changed.

    Args:
        fields: List of fields to check for changes. If None, all fields are checked.
        from_time: Only search versions since this time. If None, the start time is unbounded
        to_time: Only search versions until this time. If None, the end time is unbounded

    Returns:
        List of objects with information about the versions.
    """
```

I also changed the introspection code a little bit. Made it so the introspections are now cached per-host for the whole python lifetime (and not per data client as it used to be) + made it so the validators run every time you run `cl._exec`.