### PR TITLE
Docs: Replace DAGsHub with DagsHub in docs and comments

### DIFF
--- a/dagshub/fastai/logger.py
+++ b/dagshub/fastai/logger.py
@@ -9,7 +9,7 @@ from ..logger import DAGsHubLogger as LoggerImpl
 
 class DAGsHubLogger(Callback):
     """
-    First, install the DAGsHub logger with
+    First, install the DagsHub logger with
     `pip install dagshub`
 
     Example of Usage:

--- a/dagshub/keras/logger.py
+++ b/dagshub/keras/logger.py
@@ -16,7 +16,7 @@ class ignore_exceptions:
 
 class DAGsHubLogger(Callback):
     """
-    First, install the DAGsHub logger with
+    First, install the DagsHub logger with
     `pip install dagshub`
 
     Example of Usage:

--- a/dagshub/storage/rclone.py
+++ b/dagshub/storage/rclone.py
@@ -80,7 +80,7 @@ def check_and_provide_install_script(quiet=False):
 
 def rclone_init(repo_owner: str, conf_path: Optional[Path] = None, update=False, quiet=False) -> Tuple[str, Path]:
     """
-    Initializes or updates the Rclone configuration for a DAGsHub repository.
+    Initializes or updates the Rclone configuration for a DagsHub repository.
 
     :param repo_owner: The owner of the repository. This is used to create a unique section in the Rclone configuration.
     :param conf_path: Optional. The path to the Rclone configuration file. If not provided, the default path is used.
@@ -137,10 +137,10 @@ def rclone_init(repo_owner: str, conf_path: Optional[Path] = None, update=False,
 
 def sync(repo: str, local_path: Union[str, os.PathLike], remote_path: Union[str, os.PathLike]):
     """
-    Synchronizes the contents of a local directory with a specified remote directory in a DAGsHub repository using
+    Synchronizes the contents of a local directory with a specified remote directory in a DagsHub repository using
     Rclone.
 
-    :param repo: A string in the ``<repo_owner>/<repo_name>`` format representing the target DAGsHub repository.
+    :param repo: A string in the ``<repo_owner>/<repo_name>`` format representing the target DagsHub repository.
     :param local_path: A Path object or string pointing to the local directory to be synchronized.
     :param remote_path: A Path object or string representing the remote directory path relative to the DagsHub Storage
         bucket root.
@@ -183,7 +183,7 @@ def sync(repo: str, local_path: Union[str, os.PathLike], remote_path: Union[str,
 
 def mount(repo: str, cache: bool = False, path: Path = None) -> os.PathLike:
     """
-    Mounts a DAGsHub repository bucket to a local directory.
+    Mounts a DagsHub repository bucket to a local directory.
 
     .. warning::
         This function is only supported on Linux machines and on macOS via FUSE for macOS (FUSE-T or macFUSE).
@@ -257,7 +257,7 @@ def mount(repo: str, cache: bool = False, path: Path = None) -> os.PathLike:
 
 def unmount(repo, path=None):
     """
-    Unmounts a previously mounted DAGsHub repository bucket from the local file system.
+    Unmounts a previously mounted DagsHub repository bucket from the local file system.
 
     :param repo: The name of the repository. Used to determine the default mount point if a custom path is
         not provided.

--- a/dagshub/streaming/filesystem.py
+++ b/dagshub/streaming/filesystem.py
@@ -300,7 +300,7 @@ class DagsHubFilesystem:
         Get the list of DagsHub remotes from the Git configuration.
 
         Returns:
-            List[str]: A list of DAGsHub remote URLs.
+            List[str]: A list of DagsHub remote URLs.
 
         :meta private:
         """

--- a/examples/pytorch-lightning/hyperparams-as-dependency/mnist_trainer.py
+++ b/examples/pytorch-lightning/hyperparams-as-dependency/mnist_trainer.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         max_epochs=hparams.max_nb_epochs,
         gpus=hparams.gpus,
         val_check_interval=0.2,
-        logger=DAGsHubLogger(should_log_hparams=False),  # This is the main point - use the DAGsHub logger!
+        logger=DAGsHubLogger(should_log_hparams=False),  # This is the main point - use the DagsHub logger!
         default_root_dir="lightning_logs",
     )
     trainer.fit(model)

--- a/examples/pytorch-lightning/hyperparams-as-output/mnist_trainer.py
+++ b/examples/pytorch-lightning/hyperparams-as-output/mnist_trainer.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         max_epochs=hparams.max_nb_epochs,
         gpus=hparams.gpus,
         val_check_interval=0.2,
-        logger=DAGsHubLogger(),  # This is the main point - use the DAGsHub logger!
+        logger=DAGsHubLogger(),  # This is the main point - use the DagsHub logger!
         default_root_dir="lightning_logs",
     )
     trainer.fit(model)


### PR DESCRIPTION
Adhering to our common naming, fixing all places where we were written as "DAGsHub" 