### PR TITLE
Bug: Fix not working very basic .is_not_null() query

### DIFF
--- a/dagshub/data_engine/model/query.py
+++ b/dagshub/data_engine/model/query.py
@@ -151,8 +151,15 @@ class QueryFilterTree:
                 # Negation in the operation - prepend a not node before the current node
                 tree = self._operand_tree
                 parent_id = tree.parent(node.identifier)
-                not_node = tree.create_node("not", parent=parent_id)
-                tree.move_node(node.identifier, not_node.identifier)
+                if parent_id is None:
+                    # Root node - need to recreate a new tree with the not node as the top node
+                    new_tree = Tree()
+                    not_node = new_tree.create_node("not")
+                    new_tree.paste(not_node.identifier, self._operand_tree)
+                    self._operand_tree = new_tree
+                else:
+                    not_node = tree.create_node("not", parent=parent_id)
+                    tree.move_node(node.identifier, not_node.identifier)
                 op = op[1:]
             node.tag = op
             node.data.update({"value": other})

--- a/tests/data_engine/test_querying.py
+++ b/tests/data_engine/test_querying.py
@@ -446,6 +446,14 @@ def test_isnull_deserialization(ds):
     assert queried.get_query().filter.serialize() == deserialized.serialize()
 
 
+def test_is_not_null_serialization(ds):
+    add_string_fields(ds, "col1")
+    queried = ds["col1"].is_not_null()
+    expected = {"filter": {"key": "col1", "value": "", "valueType": "STRING", "comparator": "IS_NULL"}, "not": True}
+
+    assert queried.get_query().filter.serialize() == expected
+
+
 def test_isnull_raises_not_on_field(ds):
     with pytest.raises(RuntimeError):
         ds.is_null()


### PR DESCRIPTION
Reproduction (ds is a fresh datasource without any filters applied):
```
ds["x"].is_not_null()
```

Before this PR this command failed. Should be working now.