### PR TITLE
Created generic prediction + annotation mechanism

### DIFF
--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -563,6 +563,7 @@ class QueryResult:
 
         Args:
             repo: repository to extract the model from
+            name: name of the model in the repository's MLflow registry.
             host: address of the DagsHub instance with the repo to load the model from.
                  Set it if the model is hosted on a different DagsHub instance than the datasource.
             version: version of the model in the mlflow registry.

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -538,7 +538,11 @@ class QueryResult:
                         remote_path,
                         {
                             log_to_field: json.dumps(predictions[remote_path][0]).encode("utf-8"),
-                            f"{log_to_field}_score": json.dumps(predictions[remote_path][1]).encode("utf-8"),
+                            f"{log_to_field}_score": (
+                                None
+                                if len(predictions[remote_path]) == 1
+                                else json.dumps(predictions[remote_path][1]).encode("utf-8")
+                            ),
                         },
                     )
         return predictions
@@ -856,7 +860,7 @@ class QueryResult:
         a generic object.
 
         Args:
-            generic: function that returns predictions in the form of (prediction, prediction_score: Optional[float] = None)
+            generic: function that handles batched input and returns predictions in the form of (prediction, prediction_score: Optional[float] = None)
             batch_size: (optional, default: 1) number of datapoints to run inference on simultaneously
             log_to_field: (optional, default: 'prediction') write prediction results to metadata logged in data engine.
             If None, just returns predictions.
@@ -885,7 +889,11 @@ class QueryResult:
                         remote_path,
                         {
                             log_to_field: json.dumps(predictions[remote_path][0]).encode("utf-8"),
-                            f"{log_to_field}_score": json.dumps(predictions[remote_path][1]).encode("utf-8"),
+                            f"{log_to_field}_score": (
+                                None
+                                if len(predictions[remote_path]) == 1
+                                else json.dumps(predictions[remote_path][1]).encode("utf-8")
+                            ),
                         },
                     )
         return predictions
@@ -896,7 +904,7 @@ class QueryResult:
         a generic object.
 
         Args:
-            generic: function that returns (annotation, prediction_score)
+            generic: function that handles batched input and returns predictions in the form of (prediction, prediction_score: Optional[float] = None)
             batch_size: (optional, default: 1) number of datapoints to run inference on simultaneously
             log_to_field: (optional, default: 'prediction') write prediction results to metadata logged in data engine.
         """

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -58,7 +58,12 @@ else:
 
 logger = logging.getLogger(__name__)
 
-CustomPredictor = Callable[List[str], List[Tuple[Any, Optional[float]]]]
+CustomPredictor = Callable[
+    [
+        List[str],
+    ],
+    List[Tuple[Any, Optional[float]]],
+]
 
 
 class VisualizeError(Exception):

--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -964,42 +964,6 @@ class QueryResult:
         )
         self.datasource.metadata_field(log_to_field).set_annotation().apply()
 
-    def annotate_with_mlflow_model(
-        self,
-        repo: str,
-        name: str,
-        post_hook: Callable = lambda x: x,
-        pre_hook: Callable = lambda x: x,
-        host: Optional[str] = None,
-        version: str = "latest",
-        batch_size: int = 1,
-        log_to_field: str = "annotation",
-    ) -> Optional[str]:
-        """
-        Sends all the datapoints returned in this QueryResult to an MLFlow model which automatically labels datapoints.
-
-        Args:
-            repo: repository to extract the model from
-            name: name of the model in the mlflow registry
-            version: (optional, default: 'latest') version of the model in the mlflow registry
-            pre_hook: (optional, default: identity function) function that runs
-            before the datapoint is sent to the model
-            post_hook: (optional, default: identity function) function that converts
-            mlflow model output converts to labelstudio format
-            batch_size: (optional, default: 1) batched annotation size
-        """
-        self.predict_with_mlflow_model(
-            repo,
-            name,
-            host=host,
-            version=version,
-            pre_hook=pre_hook,
-            post_hook=post_hook,
-            batch_size=batch_size,
-            log_to_field=log_to_field,
-        )
-        self.datasource.metadata_field(log_to_field).set_annotation().apply()
-
     def annotate(
         self,
         open_project: bool = True,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ pytest-mock==3.14.0
 fiftyone==0.23.8
 datasets==2.19.1
 ultralytics==8.3.47
-dagshub-annotation-converter>=0.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-mock==3.14.0
 fiftyone==0.23.8
 datasets==2.19.1
 ultralytics==8.3.47
+dagshub-annotation-converter>=0.1.0


### PR DESCRIPTION
Decomposes `predict_with_mlflow` and `annotate_with_mlflow` for users that have custom inference functions / already saved annotations (and don't want to re-generate it lazily), as a generic function that returns annotations given batched requests.

+ minor code resilience, docstrings, requirements updates