### PR TITLE
Bug: Uploading a file to a bucket with no remote_path argument fails + minor CLI doc change

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ run ``pip install dagshub[jupyter]`` to install additional dependencies to enhan
     :maxdepth: 1
 
     Back to DagsHub Docs <https://dagshub.com/docs>
+    reference/cli
     reference/setup
     reference/auth
     reference/data_engine/index
@@ -33,7 +34,6 @@ run ``pip install dagshub[jupyter]`` to install additional dependencies to enhan
     reference/mlflow_util
     reference/troubleshooting
 
-    reference/cli
 
 ..  Files after this one are hidden and aren't exposed (not exposing them to the user due to deprecation)
     reference/metric_logging

--- a/tests/dda/upload/conftest.py
+++ b/tests/dda/upload/conftest.py
@@ -1,3 +1,6 @@
+import unittest.mock
+from typing import List, Tuple
+
 import pytest
 
 from dagshub.upload import Repo
@@ -9,3 +12,29 @@ def upload_repo(repouser: str, reponame: str, mock_api: MockApi) -> Repo:
     mock_api.enable_uploads()
     repo = Repo(repouser, reponame)
     yield repo
+
+
+class MockS3Client(unittest.mock.Mock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uploaded_files: List[Tuple[str, str]] = []
+
+    def upload_file(self, *args):
+        path = f"{args[1]}/{args[2]}"
+        self.uploaded_files.append((path, args[0]))
+
+
+@pytest.fixture()
+def mock_s3_client():
+    return MockS3Client()
+
+
+@pytest.fixture
+def mock_s3(monkeypatch, mock_s3_client):
+    def get_client(*args, **kwargs):
+        return mock_s3_client
+
+    # Need to monkeypatch in the file that is importing, not the original function that's being imported
+    monkeypatch.setattr("dagshub.upload.wrapper.get_repo_bucket_client", get_client)
+
+    return mock_s3_client


### PR DESCRIPTION
To trigger a bug in the current version:
```
$ dagshub upload --bucket <user>/<repo> file.txt
```

This fails if both of:
- There's no "remote path" argument
- Uploading a file
are satisfied

Added tests for this case + most of the test cases for bucket uploads.

Along the way I tried to reorder the CLI a bit. I made it so the commands show up in order of appearance when you're calling `dagshub help`. Sadly this didn't carry over to the docs, where everything is still sorted alphabetically. Seems like a bug with `sphinx-click`.
But I also put the CLI docs as the first item in the doc sidebar as discussed.

+ there are some typing changes to satisfy MyPy