### PR TITLE
Bug: Don't add "images" to the annotations for yolo export

### DIFF
--- a/dagshub/data_engine/model/query_result.py
+++ b/dagshub/data_engine/model/query_result.py
@@ -752,8 +752,6 @@ class QueryResult:
 
         # If there's no folder "images" in the datasource, prepend it to the path
         if not any("images/" in ann.filename for ann in annotations):
-            for ann in annotations:
-                ann.filename = os.path.join("images", ann.filename)
             image_download_path = Path(download_dir) / "images"
 
         context = YoloContext(annotation_type=annotation_type, categories=categories)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     "python-dateutil",
     "boto3",
     "semver",
-    "dagshub-annotation-converter>=0.1.0",
+    "dagshub-annotation-converter>=0.1.3",
 ]
 
 extras_require = {


### PR DESCRIPTION
To reproduce this bug, need to create a datasource with annotations, that doesn't have "images" anywhere in the paths.
On running `ds.all().export_as_yolo()` the labels get placed inside of `data/images/labels/....` folder, instead of the expected `data/labels/...`

Also bumping the annotation converter version along the way to one that also has a fix for this bug