### PR TITLE
Infra: Drop boto3 restriction

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -18,18 +18,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dagshub/python-license-checker-action@v1
     - run: |
         commit="$GITHUB_SHA"
         base_link="github.com/$GITHUB_REPOSITORY"
         date=`date "+%B %e %Y"`
         awk -F',' -v "commit=$commit" -v "base_link=$base_link" -v "date=$date" '{OFS=","; print base_link,commit,date,$1_$2,$3,$4}' licenses.csv > python-licenses.csv
-        
+
     - name: Upload python license report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-licenses.csv
         path: python-licenses.csv
         if-no-files-found: error
-      
+

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     "treelib>=1.6.4",
     "pathvalidate>=3.0.0",
     "python-dateutil",
-    "boto3<1.36.0",
+    "boto3",
     "semver",
     "dagshub-annotation-converter>=0.1.3",
 ]


### PR DESCRIPTION
Now that there's a backend PR ready to merge that handles the chunked uploads correctly, we can drop the `boto3<1.36.0` restriction

Also bumping the version of the deprecated upload-actions GH Action that was preventing the license checker