### PR TITLE
Tests: Fix platform-dependent path objects breaking on windows

### DIFF
--- a/tests/dda/upload/test_wrapper.py
+++ b/tests/dda/upload/test_wrapper.py
@@ -92,7 +92,7 @@ def test_bucket_upload(upload_repo, reponame, mock_api, mock_s3, test_dirs, remo
     if remote_path:
         expected_paths = set([f"{reponame}/{remote_path}{p}" for p in os.listdir(test_dirs)])
     else:
-        relpath = os.path.relpath(test_dirs, os.getcwd())
+        relpath = Path(test_dirs).relative_to(Path(".")).as_posix()
         expected_paths = set([f"{reponame}/{relpath}/{p}" for p in os.listdir(test_dirs)])
     print(expected_paths)
     upload_repo.upload(local_path=test_dirs, remote_path=remote_path, bucket=True)
@@ -107,7 +107,7 @@ def test_bucket_upload_single_file(upload_repo, reponame, mock_api, mock_s3, tes
         expected_path = f"{reponame}/{remote_path}"
     else:
         dirpath = Path(test_file).parent.resolve().relative_to(os.getcwd())
-        expected_path = str(reponame / dirpath / filename)
+        expected_path = (reponame / dirpath / filename).as_posix()
     upload_repo.upload(local_path=test_file, remote_path=remote_path, bucket=True)
     actual_paths = [p[0] for p in mock_s3.uploaded_files]
     assert actual_paths == [expected_path]

--- a/tests/model_loading/test_locate.py
+++ b/tests/model_loading/test_locate.py
@@ -1,4 +1,4 @@
-from pathlib import PosixPath
+from pathlib import PurePosixPath
 
 import pytest
 
@@ -55,7 +55,7 @@ def test_found_when_passed_path(repo_mock):
     locator = ModelLocator(repo_mock, path=dir_path)
     loader = locator.find_model()
     assert isinstance(loader, RepoModelLoader)
-    assert loader.path == PosixPath(dir_path)
+    assert loader.path == PurePosixPath(dir_path)
 
 
 def test_found_when_passed_bucket_root_as_path(repo_mock):
@@ -65,7 +65,7 @@ def test_found_when_passed_bucket_root_as_path(repo_mock):
     locator = ModelLocator(repo_mock, path=bucket_name)
     loader = locator.find_model()
     assert isinstance(loader, BucketModelLoader)
-    assert loader.path == PosixPath(f"s3/{bucket_name}")
+    assert loader.path == PurePosixPath(f"s3/{bucket_name}")
 
 
 def test_found_in_repo_when_bucket_name_is_longer(repo_mock):
@@ -76,7 +76,7 @@ def test_found_in_repo_when_bucket_name_is_longer(repo_mock):
     locator = ModelLocator(repo_mock, path="some-bucket/random/prefixasdf")
     loader = locator.find_model()
     assert isinstance(loader, RepoModelLoader)
-    assert loader.path == PosixPath("some-bucket/random/prefixasdf")
+    assert loader.path == PurePosixPath("some-bucket/random/prefixasdf")
 
 
 def test_not_found_when_path_is_longer_than_bucket(repo_mock):


### PR DESCRIPTION
Fix using platform-dependent Path objects, to instead use `PurePosixPath` and `Path().as_posix()`