### PR TITLE
Chore: Drop python 3.8 and update dev requirements

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-setuptools==70.0.0
-pytest==8.2.1
-respx==0.21.1
+setuptools==80.4.0
+pytest==8.3.5
+respx==0.22.0
 pytest-git==1.8.0
-pytest-env==1.1.3
+pytest-env==1.1.5
 pytest-mock==3.14.0
-fiftyone==0.23.8
-datasets==2.19.1
-ultralytics==8.3.47
+fiftyone==1.5.2
+datasets==3.6.0
+ultralytics==8.3.132

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,6 @@ install_requires = [
     "boto3",
     "semver",
     "dagshub-annotation-converter>=0.1.5",
-    # Lock version of mypy_extensions, which is a transitive dependency of dataclasses-json
-    # Version 1.1.0 and up don't get its license parsed correctly by pip-license
-    "mypy_extensions==1.0.0",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ install_requires = [
     "boto3",
     "semver",
     "dagshub-annotation-converter>=0.1.5",
+    # Lock version of mypy_extensions, which is a transitive dependency of dataclasses-json
+    # Version 1.1.0 and up don't get its license parsed correctly by pip-license
+    "mypy_extensions==1.0.0",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     entry_points={"console_scripts": ["dagshub = dagshub.common.cli:cli"]},
 )


### PR DESCRIPTION
Drop Python 3.8 since it's EOL, update the development dependencies