### PR TITLE
RepoAPI LabelStudio: Raise retry count for ls studio initialization wait

### DIFF
--- a/dagshub/common/api/repo.py
+++ b/dagshub/common/api/repo.py
@@ -79,7 +79,7 @@ class RepoAPI:
         else:
             self.auth = auth
 
-    @retry(retry=retry_if_exception_type(LSInitializingError), wait=wait_fixed(3), stop=stop_after_attempt(5))
+    @retry(retry=retry_if_exception_type(LSInitializingError), wait=wait_fixed(3), stop=stop_after_attempt(40))
     def _tenacious_ls_request(self, *args, **kwargs):
         res = self._http_request(*args, **kwargs)
         if res.text.startswith("<!DOCTYPE html>"):


### PR DESCRIPTION
Raise the time spent waiting for the ls workspace to spin up fro 15 second to 2 minutes