### PR TITLE
fix: show full help text for dagshub repo command

### DIFF
--- a/dagshub/common/cli.py
+++ b/dagshub/common/cli.py
@@ -327,7 +327,7 @@ def repo():
     pass
 
 
-@repo.command()
+@repo.command(short_help="Create a repo; optional data upload and local clone.")
 @click.argument("repo_name")
 @click.option("-u", "--upload-data", help="Upload data from specified url to new repository")
 @click.option("-c", "--clone", is_flag=True, help="Clone repository locally")


### PR DESCRIPTION
## Description

Click applies a default length limit when deriving subcommand summaries from docstrings. The `create` subcommand under `dagshub repo` was listed with a truncated one-line summary in `dagshub repo --help`.

Set an explicit `short_help` on `repo create` so the Commands table shows a complete, readable line. Full `dagshub repo create --help` text is unchanged.

Closes #310

## How to test

```bash
dagshub repo --help
```

Confirm the `create` row under Commands shows the full short help text. Run `dagshub repo create --help` to confirm the long-form docstring is unchanged.