### PR TITLE
[codex] fix boolean env parsing in client config

### DIFF
--- a/dagshub/common/config.py
+++ b/dagshub/common/config.py
@@ -21,6 +21,7 @@ DAGSHUB_PASSWORD_KEY = "DAGSHUB_PASSWORD"
 HTTP_TIMEOUT_KEY = "DAGSHUB_HTTP_TIMEOUT"
 DAGSHUB_QUIET_KEY = "DAGSHUB_QUIET"
 DISABLE_TRACEPARENT_KEY = "DAGSHUB_DISABLE_TRACEPARENT"
+TRUE_VALUES = {"1", "true", "yes", "on"}
 
 
 def set_host(new_host: str):
@@ -30,6 +31,13 @@ def set_host(new_host: str):
 
     global hostname, host, parsed_host
     hostname, host, parsed_host = _hostname, _host, _parsed_host
+
+
+def _get_boolean_env(key: str, default: bool = False) -> bool:
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    return value.strip().lower() in TRUE_VALUES
 
 
 hostname = ""
@@ -44,12 +52,12 @@ username = os.environ.get(DAGSHUB_USERNAME_KEY)
 password = os.environ.get(DAGSHUB_PASSWORD_KEY)
 custom_user_agent_suffix = f" dagshub-client-python/{__version__}"
 requests_headers = {"user-agent": USER_AGENT + custom_user_agent_suffix}
-http_timeout = os.environ.get(HTTP_TIMEOUT_KEY, 30)
+http_timeout = float(os.environ.get(HTTP_TIMEOUT_KEY, 30))
 REPO_INFO_URL = "api/v1/repos/{owner}/{reponame}"
 
-quiet = bool(os.environ.get(DAGSHUB_QUIET_KEY, False))
+quiet = _get_boolean_env(DAGSHUB_QUIET_KEY)
 
-disable_traceparent = bool(os.environ.get(DISABLE_TRACEPARENT_KEY, False))
+disable_traceparent = _get_boolean_env(DISABLE_TRACEPARENT_KEY)
 
 # DVC config templates
 CONFIG_GITIGNORE = "/config.local\n/tmp\n/cache"

--- a/dagshub/common/config.py
+++ b/dagshub/common/config.py
@@ -52,7 +52,7 @@ username = os.environ.get(DAGSHUB_USERNAME_KEY)
 password = os.environ.get(DAGSHUB_PASSWORD_KEY)
 custom_user_agent_suffix = f" dagshub-client-python/{__version__}"
 requests_headers = {"user-agent": USER_AGENT + custom_user_agent_suffix}
-http_timeout = int(os.environ.get(HTTP_TIMEOUT_KEY, 30))
+http_timeout = os.environ.get(HTTP_TIMEOUT_KEY, 30)
 REPO_INFO_URL = "api/v1/repos/{owner}/{reponame}"
 
 quiet = _get_boolean_env(DAGSHUB_QUIET_KEY)

--- a/dagshub/common/config.py
+++ b/dagshub/common/config.py
@@ -52,7 +52,7 @@ username = os.environ.get(DAGSHUB_USERNAME_KEY)
 password = os.environ.get(DAGSHUB_PASSWORD_KEY)
 custom_user_agent_suffix = f" dagshub-client-python/{__version__}"
 requests_headers = {"user-agent": USER_AGENT + custom_user_agent_suffix}
-http_timeout = float(os.environ.get(HTTP_TIMEOUT_KEY, 30))
+http_timeout = int(os.environ.get(HTTP_TIMEOUT_KEY, 30))
 REPO_INFO_URL = "api/v1/repos/{owner}/{reponame}"
 
 quiet = _get_boolean_env(DAGSHUB_QUIET_KEY)

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -50,9 +50,9 @@ class ConfigTestCase(unittest.TestCase):
         self.assertFalse(config.quiet)
         self.assertTrue(config.disable_traceparent)
 
-    def test_http_timeout_is_loaded_as_a_number(self):
-        with patch.dict(os.environ, {"DAGSHUB_HTTP_TIMEOUT": "12.5"}, clear=False):
+    def test_http_timeout_is_loaded_as_an_integer(self):
+        with patch.dict(os.environ, {"DAGSHUB_HTTP_TIMEOUT": "12"}, clear=False):
             config = load_config_module()
 
-        self.assertEqual(config.http_timeout, 12.5)
-        self.assertIsInstance(config.http_timeout, float)
+        self.assertEqual(config.http_timeout, 12)
+        self.assertIsInstance(config.http_timeout, int)

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -49,10 +49,3 @@ class ConfigTestCase(unittest.TestCase):
 
         self.assertFalse(config.quiet)
         self.assertTrue(config.disable_traceparent)
-
-    def test_http_timeout_is_loaded_as_an_integer(self):
-        with patch.dict(os.environ, {"DAGSHUB_HTTP_TIMEOUT": "12"}, clear=False):
-            config = load_config_module()
-
-        self.assertEqual(config.http_timeout, 12)
-        self.assertIsInstance(config.http_timeout, int)

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -1,0 +1,58 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "dagshub" / "common" / "config.py"
+
+
+def load_config_module():
+    fake_dagshub = types.ModuleType("dagshub")
+    fake_dagshub.__version__ = "test-version"
+
+    fake_appdirs = types.ModuleType("appdirs")
+    fake_appdirs.user_cache_dir = lambda app_name: f"/tmp/{app_name}"
+
+    fake_httpx = types.ModuleType("httpx")
+    fake_httpx_client = types.ModuleType("httpx._client")
+    fake_httpx_client.USER_AGENT = "test-agent"
+
+    spec = importlib.util.spec_from_file_location("test_dagshub_common_config", CONFIG_PATH)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(
+        sys.modules,
+        {
+            "dagshub": fake_dagshub,
+            "appdirs": fake_appdirs,
+            "httpx": fake_httpx,
+            "httpx._client": fake_httpx_client,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+class ConfigTestCase(unittest.TestCase):
+    def test_boolean_env_flags_are_parsed_from_string_values(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DAGSHUB_QUIET": "false",
+                "DAGSHUB_DISABLE_TRACEPARENT": "1",
+            },
+            clear=False,
+        ):
+            config = load_config_module()
+
+        self.assertFalse(config.quiet)
+        self.assertTrue(config.disable_traceparent)
+
+    def test_http_timeout_is_loaded_as_a_number(self):
+        with patch.dict(os.environ, {"DAGSHUB_HTTP_TIMEOUT": "12.5"}, clear=False):
+            config = load_config_module()
+
+        self.assertEqual(config.http_timeout, 12.5)
+        self.assertIsInstance(config.http_timeout, float)


### PR DESCRIPTION
## What changed

- keep boolean env parsing explicit for `DAGSHUB_QUIET` and `DAGSHUB_DISABLE_TRACEPARENT`
- leave `DAGSHUB_HTTP_TIMEOUT` type unchanged after review follow-up
- add self-contained config test covering boolean env parsing

## Why

Boolean env parsing was clearly wrong because any non-empty string became truthy. Timeout casting looked riskier than useful, so final version keeps only low-risk behavior fix.

## Impact

- `DAGSHUB_QUIET=false` now disables quiet mode as expected
- `DAGSHUB_DISABLE_TRACEPARENT=1` still enables traceparent disabling
- timeout behavior stays aligned with existing contract

## Validation

- `python3 -m unittest tests.common.test_config`
- `python3 -m py_compile dagshub/common/config.py tests/common/test_config.py`
