### PR TITLE
Send the datasource when downloading a blob

### DIFF
--- a/dagshub/data_engine/model/datasource_state.py
+++ b/dagshub/data_engine/model/datasource_state.py
@@ -121,7 +121,13 @@ class DatasourceState:
         """
         Returns the path for the blob of a datasource
         """
-        return f"{self.repoApi.data_engine_url}/blob/{sha}"
+        url = f"{self.repoApi.data_engine_url}/blob/{sha}"
+        if self.id is None:
+            return url
+        # Blobs are stored per datasource. The server can find the blob without this, but only
+        # by searching the repo's datasources, so tell it where to look. Older servers ignore
+        # the unknown parameter and still serve the blob.
+        return f"{url}?datasource={self.id}"
 
     @cached_property
     def root_content_path(self) -> str:

--- a/tests/data_engine/annotation_import/test_annotation_parsing.py
+++ b/tests/data_engine/annotation_import/test_annotation_parsing.py
@@ -3,6 +3,7 @@ from os import PathLike
 from pathlib import Path
 from typing import Union
 from unittest.mock import MagicMock
+from urllib.parse import urlsplit
 
 import pytest
 from dagshub_annotation_converter.ir.image import IRSegmentationImageAnnotation
@@ -60,7 +61,9 @@ def mock_annotation_query_result(
 
 def mock_get_blob(*args, **kwargs) -> Union[bytes, PathLike]:
     download_url: str = args[0]
-    blob_hash = download_url.split("/")[-1]
+    # The hash is the last path segment; the url may also carry a ?datasource= hint, which
+    # the real server reads separately and which is not part of the hash.
+    blob_hash = urlsplit(download_url).path.split("/")[-1]
     load_into_memory = args[4]
     blob_path = _res_folder / f"{blob_hash}.json"
 

--- a/tests/data_engine/test_datasource_state.py
+++ b/tests/data_engine/test_datasource_state.py
@@ -84,3 +84,19 @@ def test_bucket_regex_incorrect(in_str, mock_dagshub_auth):
     ds.source_type = DatasourceType.REPOSITORY
     with pytest.raises(InvalidPathFormatError):
         ds.path_parts()
+
+
+def test_blob_path_includes_datasource(ds):
+    source = ds.source
+    sha = "a" * 64
+
+    assert source.blob_path(sha) == f"{source.repoApi.data_engine_url}/blob/{sha}?datasource={source.id}"
+
+
+def test_blob_path_without_datasource_id(mock_dagshub_auth):
+    # The server falls back to searching the repo's datasources when the hint is absent,
+    # so an unsaved datasource must still produce a usable url rather than "datasource=None".
+    source = DatasourceState(repo="user/repo")
+    sha = "a" * 64
+
+    assert source.blob_path(sha) == f"{source.repoApi.data_engine_url}/blob/{sha}"


### PR DESCRIPTION
The server now stores data engine metadata blobs under a per-datasource prefix instead of a repo-wide one, so that deleting a datasource can actually delete its blobs.

The server can still serve a blob when it isn't told which datasource it belongs to — but only by checking the legacy location and then searching the repo's datasources one at a time. We already know the datasource here, so we may as well say so.

## The change

`blob_path` appends `?datasource={id}`, which lets the server go straight to the blob.

**This is an optimization, not a requirement.** Nothing breaks without it, in either direction:

- **Old client + new server:** no parameter, so the server searches. Correct, just does a bit more work.
- **New client + old server:** an unknown query parameter, which the old server ignores.
- **Datasource with no id yet** (never saved): the parameter is omitted rather than sent as `datasource=None`.

So this can ship on its own schedule; the server PR does not depend on it.

## Testing

Two new tests in `tests/data_engine/test_datasource_state.py`: the url carries the datasource, and a datasource without an id still produces a usable url. Full suite passes (355 tests).

Also fixed the annotation test's blob mock, which derived the blob hash from the last path segment of the download url and so swallowed the query string. It now parses the url the way the server does — path for the hash, query separately. The real client is unaffected: it caches by hash, independently of the url.
