### PR TITLE
Add manual-dispatch release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type (ignored if explicit_version is set)"
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      explicit_version:
+        description: "Explicit version to release, e.g. 1.2.3 (overrides bump)"
+        required: false
+        type: string
+      release_title_suffix:
+        description: "Optional summary appended to the release title, e.g. \"- COCO annotation support\""
+        required: false
+        type: string
+      draft:
+        description: "Create the GitHub release as a draft instead of publishing immediately (skips PyPI publish until you hit Publish)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Compute new version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          EXPLICIT_VERSION: ${{ inputs.explicit_version }}
+        run: |
+          set -euo pipefail
+          current=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' dagshub/__init__.py)
+          if [ -z "$current" ]; then
+            echo "Could not find __version__ in dagshub/__init__.py" >&2
+            exit 1
+          fi
+
+          if [ -n "$EXPLICIT_VERSION" ]; then
+            if ! [[ "$EXPLICIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "explicit_version '$EXPLICIT_VERSION' is not a valid X.Y.Z semver" >&2
+              exit 1
+            fi
+            new="$EXPLICIT_VERSION"
+          else
+            IFS='.' read -r major minor patch <<< "$current"
+            case "$BUMP" in
+              major) new="$((major + 1)).0.0" ;;
+              minor) new="${major}.$((minor + 1)).0" ;;
+              patch) new="${major}.${minor}.$((patch + 1))" ;;
+              *) echo "Unknown bump type '$BUMP'" >&2; exit 1 ;;
+            esac
+          fi
+
+          if [ "$new" = "$current" ]; then
+            echo "New version '$new' is the same as the current version" >&2
+            exit 1
+          fi
+
+          if git rev-parse "$new" >/dev/null 2>&1; then
+            echo "Tag '$new' already exists" >&2
+            exit 1
+          fi
+
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version and commit to main
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          set -euo pipefail
+          sed -i "s/^__version__ = \".*\"/__version__ = \"${NEW_VERSION}\"/" dagshub/__init__.py
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dagshub/__init__.py
+          git commit -m "${NEW_VERSION} version bump"
+          git push origin HEAD:main
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+          TITLE_SUFFIX: ${{ inputs.release_title_suffix }}
+          DRAFT: ${{ inputs.draft }}
+        run: |
+          set -euo pipefail
+          title="${NEW_VERSION} ${TITLE_SUFFIX}"
+          draft_flag=()
+          if [ "$DRAFT" = "true" ]; then
+            draft_flag=(--draft)
+          fi
+          gh release create "$NEW_VERSION" \
+            --target main \
+            --title "$title" \
+            --generate-notes \
+            "${draft_flag[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
           echo "new=$new" >> "$GITHUB_OUTPUT"
 
       - name: Bump version and commit to main
+        id: commit
         env:
           NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
@@ -92,6 +93,7 @@ jobs:
           git add dagshub/__init__.py
           git commit -m "${NEW_VERSION} version bump"
           git push origin HEAD:main
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
         env:
@@ -99,6 +101,7 @@ jobs:
           NEW_VERSION: ${{ steps.version.outputs.new }}
           TITLE_SUFFIX: ${{ inputs.release_title_suffix }}
           DRAFT: ${{ inputs.draft }}
+          TARGET_SHA: ${{ steps.commit.outputs.sha }}
         run: |
           set -euo pipefail
           title="${NEW_VERSION} ${TITLE_SUFFIX}"
@@ -107,7 +110,7 @@ jobs:
             draft_flag=(--draft)
           fi
           gh release create "$NEW_VERSION" \
-            --target main \
+            --target "$TARGET_SHA" \
             --title "$title" \
             --generate-notes \
             "${draft_flag[@]}"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` GitHub Action (`.github/workflows/release.yml`) that automates the existing manual release process: bump `__version__` in `dagshub/__init__.py`, commit to `main`, and cut a GitHub Release (auto-generated notes), which in turn triggers the existing `python-publish.yml` PyPI publish on release.
- Inputs: `bump` (patch/minor/major), `explicit_version` (overrides bump), `release_title_suffix` (appended to release title), `draft` (create as draft to review before publishing).

## Test plan
- [ ] Run the workflow manually via `workflow_dispatch` with `draft: true` on a test version and confirm it bumps the version, commits to main, and creates a draft release without publishing to PyPI.
- [ ] Confirm `python-publish.yml` still fires correctly when the draft release is published.