### PR TITLE
Release workflow: explicitly dispatch PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   release:
@@ -114,3 +115,13 @@ jobs:
             --title "$title" \
             --generate-notes \
             "${draft_flag[@]}"
+
+      # GitHub Actions does not cascade the `release: published` event when the release is
+      # created using the default GITHUB_TOKEN, so python-publish.yml would never fire on its
+      # own. Dispatch it explicitly instead of relying on that event.
+      - name: Trigger PyPI publish
+        if: inputs.draft != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ steps.commit.outputs.sha }}
+        run: gh workflow run python-publish.yml --ref "$TARGET_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,5 +123,5 @@ jobs:
         if: inputs.draft != true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_SHA: ${{ steps.commit.outputs.sha }}
-        run: gh workflow run python-publish.yml --ref "$TARGET_SHA"
+          RELEASE_TAG: ${{ steps.version.outputs.new }}
+        run: gh workflow run python-publish.yml --ref "$RELEASE_TAG"


### PR DESCRIPTION
## Summary
- The release workflow's `gh release create` step ran with the default `GITHUB_TOKEN`. GitHub Actions does not propagate the `release: published` event to other workflows when the triggering action used the default token, so `python-publish.yml` never actually fired.
- Confirmed by running the release workflow for 0.7.1: the GitHub release was created correctly, but the package never reached PyPI until manually dispatched.
- Fix: after creating the release, explicitly `gh workflow run python-publish.yml --ref <bump-commit-sha>` (skipped when `draft: true`, matching the existing "don't publish drafts" behavior).

## Test plan
- [ ] Run the release workflow with `draft: true` and confirm the publish workflow is *not* triggered.
- [ ] Run the release workflow with `draft: false` on a test version and confirm `python-publish.yml` fires automatically and the version lands on PyPI.