### PR TITLE
Fix trailing slash handling in repository URLs

### DIFF
--- a/dagshub/common/init.py
+++ b/dagshub/common/init.py
@@ -76,6 +76,7 @@ def init(
             repo, branch = determine_repo(root)
             url = repo.repo_url
 
+        url = url.rstrip("/")
         if url.endswith(".git"):
             url = url[:-4]
         # Extract the owner and name from the repo_url

--- a/tests/common/test_init.py
+++ b/tests/common/test_init.py
@@ -74,6 +74,15 @@ def test_init_creates_repo_under_current_user_from_url(
     )
 
 
+def test_init_from_url_ignores_trailing_slash(
+    mock_repo_api, mock_user_api, mock_create_repo, mock_get_token, mock_log_message
+):
+    dagshub.init(url="https://dagshub.com/testuser/my-repo/", mlflow=False, dvc=False)
+
+    mock_repo_api.assert_called_once_with("testuser/my-repo", host="https://dagshub.com")
+    mock_create_repo.assert_called_once_with("my-repo", host="https://dagshub.com")
+
+
 def test_init_creates_repo_under_org_from_url(
     mock_repo_api, mock_user_api, mock_create_repo, mock_get_token, mock_log_message
 ):


### PR DESCRIPTION
Repository URLs copied from a browser can end in `/`, which made `dagshub.init()` parse the repository name as empty and the owner as the repository name. Strip trailing separators before extracting the owner/name pair and cover the browser-style URL with a regression test.

Fixes #701
